### PR TITLE
[PBI 2.1: 著者が電子書籍をアップロードし登録できる] 実装完了

### DIFF
--- a/ai_generated/HANDOVER.md
+++ b/ai_generated/HANDOVER.md
@@ -16,11 +16,11 @@ output_system/
 ├── Dockerfile.backend          # バックエンド用 (ubuntu:24.04 + Node.js 20 LTS)
 ├── frontend/
 │   ├── package.json            # Next.js 15.1.8 + next-auth ^5.0.0-beta.31
-│   ├── next.config.js          # /api/* → backend rewritesプロキシ (/api/auth/* 除外)
+│   ├── next.config.js          # /api/* → backend rewritesプロキシ (beforeFiles/afterFiles分離)
 │   ├── .npmrc                  # min-release-age=7
 │   └── src/
 │       ├── lib/
-│       │   ├── api.ts          # JWTトークン管理・apiRequest()ラッパー
+│       │   ├── api.ts          # JWTトークン管理・apiRequest()/apiUploadRequest()ラッパー・Book型
 │       │   ├── auth.ts         # NextAuth.js設定 (Google/Apple Provider)
 │       │   └── session-provider.tsx  # SessionProviderラッパー (Client Component)
 │       └── app/
@@ -31,25 +31,34 @@ output_system/
 │           ├── admin/login/    # 管理者ログイン (/admin/login URL)
 │           ├── admin/dashboard/ # 管理者ダッシュボード
 │           └── author/books/  # 著者書籍管理
+│               ├── page.tsx        # 書籍一覧（削除機能付き）
+│               └── new/page.tsx    # 書籍登録（ドラッグ&ドロップ・進捗バー付き）
 └── backend/
     ├── package.json            # Express + pg + node-pg-migrate + jest/ts-jest
     ├── .npmrc                  # min-release-age=7
     ├── test/                   # ユニットテスト (jest + ts-jest)
     │   └── services/
     │       ├── auth.service.test.ts
-    │       └── oauth.service.test.ts  # OAuthサービスユニットテスト7件
+    │       ├── oauth.service.test.ts  # OAuthサービスユニットテスト7件
+    │       └── books.service.test.ts  # 書籍サービスユニットテスト18件
     └── src/
         ├── index.ts            # Expressサーバー (port 3002)
         ├── routes/
-        │   ├── index.ts        # /api/health + /api/auth
-        │   └── auth.routes.ts  # POST /login /logout /oauth, GET /me
+        │   ├── index.ts        # /api/health + /api/auth + /api/books
+        │   ├── auth.routes.ts  # POST /login /logout /oauth, GET /me
+        │   └── books.routes.ts # GET/POST /books, GET/PUT/DELETE /books/:id (multer 50MB)
         ├── controllers/
         │   ├── auth.controller.ts
-        │   └── oauth.controller.ts   # POST /api/auth/oauth
+        │   ├── oauth.controller.ts   # POST /api/auth/oauth
+        │   └── books.controller.ts   # 書籍CRUD・ファイルアップロード処理
         ├── services/
         │   ├── auth.service.ts       # login/getMe (タイミング攻撃対策)
-        │   └── oauth.service.ts      # OAuthログイン/ファンアカウント作成
-        └── models/user.model.ts
+        │   ├── oauth.service.ts      # OAuthログイン/ファンアカウント作成
+        │   ├── books.service.ts      # 書籍CRUD・S3アップロード・RBAC
+        │   └── storage.service.ts    # S3/MinIO ファイル操作 (SSEオプション)
+        └── models/
+            ├── user.model.ts
+            └── book.model.ts         # 書籍モデル (CRUD・動的SET句)
 ```
 
 ## ビルド・起動方法
@@ -71,6 +80,12 @@ docker compose up -d
 - **useSearchParams() + Suspense**: App RouterでuseSearchParams()を使うコンポーネントはSuspenseでラップ必須。プリレンダリングエラー防止
 - **next.config.js プロキシ除外**: `/api/auth/*` はNextAuth.jsが処理するためバックエンドへのプロキシから除外。正規表現 `/api/:path((?!auth/).*)` を使用
 - **NEXT_PUBLIC_API_URL=/api (相対パス)**: ブラウザからバックエンドへの直接アクセスは不可能。`/api/*` をNext.jsサーバーがrewritesでバックエンドにプロキシ転送
+- **beforeFiles rewritesでNextAuth.js競合を回避**: `/api/auth/login` 等をバックエンドにプロキシする際、`afterFiles`だと NextAuth.js の `[...nextauth]` ルートハンドラーが先にマッチしてしまう。`beforeFiles` でルートハンドラーより前に評価させることで回避
+- **S3 SSEのオプトイン**: MinIOはデフォルトでKMS未設定のため `ServerSideEncryption: 'AES256'` を渡すと500エラー。`S3_ENABLE_SSE=true` 環境変数で明示的に有効化する方式とし、開発環境ではSSEを無効、本番AWS S3では有効にできる
+- **multer メモリストレージ**: ファイルをディスクに書かず直接S3アップロード。`memoryStorage()` + `fileSize: 50MB` + `fileFilter`でPDF/EPUBのみ許可
+- **ファイルバリデーション二重チェック**: クライアントサイドでMIMEタイプ+拡張子を検証し、サーバーサイドでも `validateBookFileFormat()` で再検証。拡張子偽装対策
+- **アップロード進捗バー（シミュレーション）**: fetch APIはネイティブのアップロード進捗イベントを持たないため、`setInterval` で0→90%まで疑似的に進め、完了時に100%にする
+- **books.service.ts SSE設定**: `getServerSideEncryption()` ヘルパーで `S3_ENABLE_SSE=true` のときのみ `'AES256'` を返し、それ以外は `undefined`（storage.service.ts側でundefinedなら省略）
 - **タイミング攻撃対策**: ユーザーが存在しない場合も必ず `bcrypt.compare(password, DUMMY_HASH)` を実行
 - **Jest 30でのカスタムErrorのinstanceof**: `.statusCode === 401` のようなプロパティ検証で代替
 - **AWS SDK v3 exact pin `3.693.0`**: `^` は付けない（OOMリスク）
@@ -81,8 +96,12 @@ docker compose up -d
 - **npm ci はロックファイル必須**: Dockerfile変更前に `npm install` でロックファイルを生成
 - **auth.service.test.ts がDB接続**: `jest.mock('../../src/config/database')` と `jest.mock('../../src/models/user.model')` の両方が必要
 - **callback page と useSearchParams**: Suspenseなしで `useSearchParams()` を使うとビルドエラー
+- **MinIO KMS未設定エラー**: `storage.service.ts` で `ServerSideEncryption: options.serverSideEncryption || 'AES256'` とすると `undefined` を渡してもAES256が強制される。`||` ではなく `options.serverSideEncryption` をそのまま渡すこと
+- **NextAuth.js と `/api/auth/login` の競合**: `afterFiles` rewritesに `/api/auth/login` を入れても NextAuth.jsの `[...nextauth]` が先にマッチして400エラーになる。`beforeFiles` を使うこと
+- **multer パッケージ未登録**: Dockerコンテナ内で `npm install multer` しても `package.json` が更新されない。ホスト側のディレクトリで `npm install multer @types/multer --save` を実行すること
 
 ## 実装済み機能
 - PBI #6: 開発環境セットアップ (Next.js + Express + PostgreSQL + MinIO + Docker Compose)
 - PBI #7: 管理者・著者のメール+パスワードログイン (JWT認証・bcrypt・RBAC・監査ログ・レートリミット)
 - PBI #8: ファンのGoogle/Apple IDソーシャルログイン (NextAuth.js v5・OAuth 2.0・fanアカウント自動作成)
+- PBI #9: 著者による電子書籍アップロード・登録 (multer + MinIO S3・RBAC・AES-256 SSEオプション・ドラッグ&ドロップUI)

--- a/output_system/backend/package-lock.json
+++ b/output_system/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "3.693.0",
         "@aws-sdk/s3-request-presigner": "3.693.0",
+        "@types/multer": "^2.1.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -19,6 +20,7 @@
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
+        "multer": "^2.1.1",
         "node-pg-migrate": "^7.7.1",
         "pg": "^8.13.1",
         "uuid": "^10.0.0",
@@ -3448,7 +3450,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -3459,7 +3460,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3479,7 +3479,6 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -3492,7 +3491,6 @@
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
       "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -3505,7 +3503,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -3561,7 +3558,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/morgan": {
@@ -3581,11 +3577,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3607,21 +3611,18 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3631,7 +3632,6 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -3643,7 +3643,6 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -4356,6 +4355,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -4692,8 +4697,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -4973,6 +4988,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -7991,6 +8021,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -9217,6 +9266,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -9832,6 +9889,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -9864,7 +9927,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/output_system/backend/package.json
+++ b/output_system/backend/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.693.0",
     "@aws-sdk/s3-request-presigner": "3.693.0",
+    "@types/multer": "^2.1.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
@@ -48,6 +49,7 @@
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
+    "multer": "^2.1.1",
     "node-pg-migrate": "^7.7.1",
     "pg": "^8.13.1",
     "uuid": "^10.0.0",

--- a/output_system/backend/src/controllers/books.controller.ts
+++ b/output_system/backend/src/controllers/books.controller.ts
@@ -1,0 +1,253 @@
+/**
+ * @file books.controller.ts
+ * @description 書籍コントローラー
+ *
+ * 書籍CRUD操作のHTTPリクエスト処理を担当する。
+ * リクエストバリデーション、サービス呼び出し、レスポンス整形を行う。
+ *
+ * エンドポイント:
+ * - GET    /api/books        : 書籍一覧取得（author: 自分の書籍, admin: 全書籍）
+ * - POST   /api/books        : 書籍登録（ファイルアップロード）
+ * - GET    /api/books/:id    : 書籍詳細取得
+ * - PUT    /api/books/:id    : 書籍情報更新
+ * - DELETE /api/books/:id    : 書籍削除（S3ファイルも削除）
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { validationResult } from 'express-validator';
+import { booksService } from '../services/books.service';
+import { ValidationError } from '../utils/errors';
+import { logger } from '../utils/logger';
+
+/**
+ * GET /api/books
+ * 書籍一覧を取得する
+ * - author: 自分の書籍のみ
+ * - admin: 全書籍
+ *
+ * レスポンス (200):
+ * - books: 書籍の配列
+ * - count: 書籍数
+ *
+ * @param req - Expressリクエストオブジェクト（req.user に認証済みユーザー情報）
+ * @param res - Expressレスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function getBooks(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const userId = req.user!.userId;
+    const role = req.user!.role;
+
+    const books = await booksService.getBooks(userId, role);
+
+    res.status(200).json({
+      books,
+      count: books.length,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * POST /api/books
+ * 書籍を新規登録する（ファイルアップロード）
+ *
+ * リクエスト (multipart/form-data):
+ * - bookFile: 電子書籍ファイル（PDF/EPUB、必須）
+ * - coverImage: 表紙画像（オプション）
+ * - title: 書籍タイトル（必須）
+ * - description: 書籍説明（オプション）
+ * - metadata: JSONメタデータ（ISBN等、オプション）
+ *
+ * レスポンス (201):
+ * - book: 作成した書籍オブジェクト
+ *
+ * @param req - Expressリクエストオブジェクト（req.files にアップロードファイル）
+ * @param res - Expressレスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function createBook(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const userId = req.user!.userId;
+    // multerの fields() を使用するため req.files はオブジェクト形式
+    const files = req.files as Record<string, Express.Multer.File[]>;
+
+    // 電子書籍ファイルは必須
+    if (!files?.bookFile?.[0]) {
+      throw new ValidationError('電子書籍ファイル（bookFile）は必須です');
+    }
+
+    const bookFile = files.bookFile[0];
+    const coverImageFile = files?.coverImage?.[0];
+
+    // metadataフィールドはJSONとしてパース
+    let metadata: Record<string, unknown> | undefined;
+    if (req.body.metadata) {
+      try {
+        metadata = typeof req.body.metadata === 'string'
+          ? JSON.parse(req.body.metadata)
+          : req.body.metadata;
+      } catch {
+        throw new ValidationError('metadataは有効なJSON形式で指定してください');
+      }
+    }
+
+    const book = await booksService.createBook(userId, {
+      title: req.body.title as string,
+      description: req.body.description as string | undefined,
+      bookFile,
+      coverImageFile,
+      metadata,
+    });
+
+    logger.info('Book created via API', { bookId: book.id, authorId: userId });
+
+    res.status(201).json({ book });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * GET /api/books/:id
+ * 書籍詳細を取得する
+ * - author: 自分の書籍のみ
+ * - admin: 全書籍
+ *
+ * パスパラメータ:
+ * - id: 書籍ID（UUID）
+ *
+ * レスポンス (200):
+ * - book: 書籍オブジェクト
+ *
+ * @param req - Expressリクエストオブジェクト（req.params.id に書籍ID）
+ * @param res - Expressレスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function getBook(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { id } = req.params;
+    const userId = req.user!.userId;
+    const role = req.user!.role;
+
+    const book = await booksService.getBook(id, userId, role);
+
+    res.status(200).json({ book });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * PUT /api/books/:id
+ * 書籍情報を更新する
+ * authorは自分の書籍のみ更新可能
+ *
+ * パスパラメータ:
+ * - id: 書籍ID（UUID）
+ *
+ * リクエスト (multipart/form-data):
+ * - bookFile: 新しい電子書籍ファイル（オプション）
+ * - coverImage: 新しい表紙画像（オプション）
+ * - title: 書籍タイトル（オプション）
+ * - description: 書籍説明（オプション）
+ * - metadata: JSONメタデータ（オプション）
+ *
+ * レスポンス (200):
+ * - book: 更新後の書籍オブジェクト
+ *
+ * @param req - Expressリクエストオブジェクト
+ * @param res - Expressレスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function updateBook(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const { id } = req.params;
+    const userId = req.user!.userId;
+    const role = req.user!.role;
+    const files = req.files as Record<string, Express.Multer.File[]>;
+
+    const bookFile = files?.bookFile?.[0];
+    const coverImageFile = files?.coverImage?.[0];
+
+    // metadataフィールドはJSONとしてパース
+    let metadata: Record<string, unknown> | undefined;
+    if (req.body.metadata) {
+      try {
+        metadata = typeof req.body.metadata === 'string'
+          ? JSON.parse(req.body.metadata)
+          : req.body.metadata;
+      } catch {
+        throw new ValidationError('metadataは有効なJSON形式で指定してください');
+      }
+    }
+
+    const book = await booksService.updateBook(id, userId, role, {
+      title: req.body.title as string | undefined,
+      description: req.body.description as string | undefined,
+      bookFile,
+      coverImageFile,
+      metadata,
+    });
+
+    logger.info('Book updated via API', { bookId: id, authorId: userId });
+
+    res.status(200).json({ book });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * DELETE /api/books/:id
+ * 書籍を削除する（S3ファイルも削除）
+ * authorは自分の書籍のみ削除可能
+ *
+ * パスパラメータ:
+ * - id: 書籍ID（UUID）
+ *
+ * レスポンス (204): No Content
+ *
+ * @param req - Expressリクエストオブジェクト
+ * @param res - Expressレスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function deleteBook(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { id } = req.params;
+    const userId = req.user!.userId;
+    const role = req.user!.role;
+
+    await booksService.deleteBook(id, userId, role);
+
+    logger.info('Book deleted via API', { bookId: id, userId });
+
+    // 204 No Content（削除成功時はボディなし）
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/output_system/backend/src/models/book.model.ts
+++ b/output_system/backend/src/models/book.model.ts
@@ -1,0 +1,252 @@
+/**
+ * @file book.model.ts
+ * @description 書籍モデル
+ *
+ * booksテーブルのデータアクセスロジックを提供する。
+ * DBクエリのラッパーとして機能し、型安全なデータ取得・変更を行う。
+ *
+ * ステータス定義:
+ * - draft: 下書き（登録直後のデフォルト状態）
+ * - published: 公開中
+ * - archived: アーカイブ済み
+ */
+
+import { db } from '../config/database';
+
+/**
+ * 書籍エンティティ型
+ * booksテーブルの行データに対応する
+ */
+export interface Book {
+  /** 書籍ID（UUID） */
+  id: string;
+  /** 著者ID（usersテーブル参照） */
+  authorId: string;
+  /** 書籍タイトル */
+  title: string;
+  /** 書籍説明 */
+  description: string | null;
+  /** ファイル形式: pdf または epub */
+  format: 'pdf' | 'epub';
+  /** S3ファイルキー（暗号化済み） */
+  fileKey: string | null;
+  /** 表紙画像S3キー */
+  coverImageKey: string | null;
+  /** ファイルサイズ（bytes） */
+  fileSize: number | null;
+  /** ページ数 */
+  pageCount: number | null;
+  /** ステータス */
+  status: 'draft' | 'published' | 'archived';
+  /** メタデータ（ISBN等） */
+  metadata: Record<string, unknown>;
+  /** 作成日時 */
+  createdAt: Date;
+  /** 更新日時 */
+  updatedAt: Date;
+}
+
+/**
+ * 書籍作成パラメータ型
+ */
+export interface CreateBookParams {
+  authorId: string;
+  title: string;
+  description?: string;
+  format: 'pdf' | 'epub';
+  fileKey?: string;
+  coverImageKey?: string;
+  fileSize?: number;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * 書籍更新パラメータ型
+ * すべてのフィールドがオプション
+ */
+export interface UpdateBookParams {
+  title?: string;
+  description?: string;
+  fileKey?: string;
+  coverImageKey?: string;
+  fileSize?: number;
+  status?: 'draft' | 'published' | 'archived';
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * DBのスネークケースカラムをキャメルケースにマッピングする
+ * PostgreSQLはカラム名を小文字で返すため変換が必要
+ *
+ * @param row - DBの行データ（スネークケース）
+ * @returns キャメルケースに変換した書籍オブジェクト
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function rowToBook(row: any): Book {
+  return {
+    id: row.id,
+    authorId: row.author_id,
+    title: row.title,
+    description: row.description,
+    format: row.format,
+    fileKey: row.file_key,
+    coverImageKey: row.cover_image_key,
+    fileSize: row.file_size ? parseInt(row.file_size, 10) : null,
+    pageCount: row.page_count,
+    status: row.status,
+    metadata: row.metadata || {},
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * 書籍モデル
+ * booksテーブルへのCRUD操作を提供する
+ */
+export const BookModel = {
+  /**
+   * 著者IDで書籍一覧を取得する
+   * admin用に authorId を指定しない場合は全書籍を返す
+   *
+   * @param authorId - 著者ID（指定しない場合は全書籍）
+   * @returns 書籍の配列（作成日時降順）
+   */
+  async findByAuthorId(authorId: string): Promise<Book[]> {
+    const result = await db.query(
+      `SELECT * FROM books
+       WHERE author_id = $1
+       ORDER BY created_at DESC`,
+      [authorId]
+    );
+    return result.rows.map(rowToBook);
+  },
+
+  /**
+   * 全書籍を取得する（admin用）
+   *
+   * @returns 全書籍の配列（作成日時降順）
+   */
+  async findAll(): Promise<Book[]> {
+    const result = await db.query(
+      `SELECT * FROM books ORDER BY created_at DESC`
+    );
+    return result.rows.map(rowToBook);
+  },
+
+  /**
+   * IDで書籍を取得する
+   *
+   * @param id - 書籍ID
+   * @returns 書籍オブジェクト、存在しない場合はnull
+   */
+  async findById(id: string): Promise<Book | null> {
+    const result = await db.query(
+      `SELECT * FROM books WHERE id = $1`,
+      [id]
+    );
+    if (result.rows.length === 0) return null;
+    return rowToBook(result.rows[0]);
+  },
+
+  /**
+   * 新しい書籍を作成する
+   *
+   * @param params - 書籍作成パラメータ
+   * @returns 作成した書籍オブジェクト
+   */
+  async create(params: CreateBookParams): Promise<Book> {
+    const result = await db.query(
+      `INSERT INTO books (author_id, title, description, format, file_key, cover_image_key, file_size, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [
+        params.authorId,
+        params.title,
+        params.description || null,
+        params.format,
+        params.fileKey || null,
+        params.coverImageKey || null,
+        params.fileSize || null,
+        JSON.stringify(params.metadata || {}),
+      ]
+    );
+    return rowToBook(result.rows[0]);
+  },
+
+  /**
+   * 書籍情報を更新する
+   * 指定されたフィールドのみを更新する（部分更新）
+   *
+   * @param id - 書籍ID
+   * @param params - 更新パラメータ
+   * @returns 更新後の書籍オブジェクト、存在しない場合はnull
+   */
+  async update(id: string, params: UpdateBookParams): Promise<Book | null> {
+    // 動的にSETクローズを構築する（指定フィールドのみ更新）
+    const setClauses: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const values: any[] = [];
+    let paramIndex = 1;
+
+    if (params.title !== undefined) {
+      setClauses.push(`title = $${paramIndex++}`);
+      values.push(params.title);
+    }
+    if (params.description !== undefined) {
+      setClauses.push(`description = $${paramIndex++}`);
+      values.push(params.description);
+    }
+    if (params.fileKey !== undefined) {
+      setClauses.push(`file_key = $${paramIndex++}`);
+      values.push(params.fileKey);
+    }
+    if (params.coverImageKey !== undefined) {
+      setClauses.push(`cover_image_key = $${paramIndex++}`);
+      values.push(params.coverImageKey);
+    }
+    if (params.fileSize !== undefined) {
+      setClauses.push(`file_size = $${paramIndex++}`);
+      values.push(params.fileSize);
+    }
+    if (params.status !== undefined) {
+      setClauses.push(`status = $${paramIndex++}`);
+      values.push(params.status);
+    }
+    if (params.metadata !== undefined) {
+      setClauses.push(`metadata = $${paramIndex++}`);
+      values.push(JSON.stringify(params.metadata));
+    }
+
+    // updated_at は常に更新する
+    setClauses.push(`updated_at = CURRENT_TIMESTAMP`);
+
+    if (setClauses.length === 1) {
+      // updated_atのみの場合は更新不要
+      return this.findById(id);
+    }
+
+    values.push(id);
+    const result = await db.query(
+      `UPDATE books SET ${setClauses.join(', ')} WHERE id = $${paramIndex} RETURNING *`,
+      values
+    );
+
+    if (result.rows.length === 0) return null;
+    return rowToBook(result.rows[0]);
+  },
+
+  /**
+   * 書籍を削除する
+   *
+   * @param id - 書籍ID
+   * @returns 削除が成功した場合はtrue
+   */
+  async delete(id: string): Promise<boolean> {
+    const result = await db.query(
+      `DELETE FROM books WHERE id = $1`,
+      [id]
+    );
+    return (result.rowCount ?? 0) > 0;
+  },
+};

--- a/output_system/backend/src/routes/books.routes.ts
+++ b/output_system/backend/src/routes/books.routes.ts
@@ -1,0 +1,236 @@
+/**
+ * @file books.routes.ts
+ * @description 書籍APIルーター
+ *
+ * 書籍のCRUD操作エンドポイントを定義する。
+ * multerによるマルチパートファイルアップロードを処理する。
+ *
+ * エンドポイント:
+ * - GET    /api/books        : 書籍一覧取得（author: 自分の書籍, admin: 全書籍）
+ * - POST   /api/books        : 書籍登録（ファイルアップロード）
+ * - GET    /api/books/:id    : 書籍詳細取得
+ * - PUT    /api/books/:id    : 書籍情報更新
+ * - DELETE /api/books/:id    : 書籍削除（S3ファイルも削除）
+ *
+ * 認証・認可:
+ * - 全エンドポイントにJWT認証が必要（authenticate）
+ * - author と admin のみアクセス可能（requireRole）
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import multer, { MulterError } from 'multer';
+import { body, param } from 'express-validator';
+import { authenticate } from '../middleware/auth.middleware';
+import { requireRole } from '../middleware/rbac.middleware';
+import {
+  getBooks,
+  createBook,
+  getBook,
+  updateBook,
+  deleteBook,
+} from '../controllers/books.controller';
+import { AppError } from '../utils/errors';
+
+const router = Router();
+
+/**
+ * multerの設定
+ *
+ * メモリストレージを使用する理由:
+ * - ファイルをディスクに書き込まず、S3に直接アップロードするため
+ * - 一時ファイルの管理が不要でシンプル
+ *
+ * ファイルサイズ制限:
+ * - 受入条件3・4: 50MB以下のファイルが正常アップロード、超過時は413エラー
+ */
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
+
+/**
+ * 電子書籍ファイルのMIMEタイプフィルター
+ * multerレイヤーで基本的なフィルタリングを行い、
+ * 詳細な検証はサービスレイヤーで行う
+ *
+ * @param _req - リクエストオブジェクト（未使用）
+ * @param file - multerのファイルオブジェクト
+ * @param cb - コールバック関数
+ */
+function bookFileFilter(
+  _req: Request,
+  file: Express.Multer.File,
+  cb: multer.FileFilterCallback
+): void {
+  if (file.fieldname === 'bookFile') {
+    // 電子書籍ファイル: PDF/EPUBのみ許可
+    const allowedMimes = [
+      'application/pdf',
+      'application/epub+zip',
+      'application/x-epub+zip',
+    ];
+    if (allowedMimes.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new AppError(
+        `対応していないファイル形式です。PDFまたはEPUBをアップロードしてください。(${file.mimetype})`,
+        400,
+        'INVALID_FILE_TYPE'
+      ) as unknown as null, false);
+    }
+  } else if (file.fieldname === 'coverImage') {
+    // 表紙画像: 画像ファイルのみ許可
+    const allowedImageMimes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (allowedImageMimes.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new AppError(
+        `表紙画像は JPEG, PNG, WebP, GIF 形式のみ対応しています。(${file.mimetype})`,
+        400,
+        'INVALID_FILE_TYPE'
+      ) as unknown as null, false);
+    }
+  } else {
+    // 未知のフィールドは拒否
+    cb(null, false);
+  }
+}
+
+/**
+ * multerインスタンスの設定
+ * - memoryStorage: ファイルをメモリ上のBufferに保存（S3直接アップロード用）
+ * - limits.fileSize: 50MBでサイズ制限（MulterError LIMIT_FILE_SIZE）
+ * - fileFilter: PDF/EPUB以外のファイルは拒否
+ */
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_FILE_SIZE_BYTES,
+    files: 2, // bookFile + coverImage の最大2ファイル
+  },
+  fileFilter: bookFileFilter,
+});
+
+/**
+ * multerエラーをHTTPレスポンスに変換するエラーハンドラー
+ * multerのエラーはExpressの通常エラーハンドラーでは処理されないため、
+ * ルートレベルで個別にハンドリングする
+ *
+ * @param err - エラーオブジェクト
+ * @param _req - リクエストオブジェクト（未使用）
+ * @param _res - レスポンスオブジェクト（未使用）
+ * @param next - 次のミドルウェア
+ */
+function multerErrorHandler(
+  err: Error,
+  _req: Request,
+  _res: Response,
+  next: NextFunction
+): void {
+  if (err instanceof MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      // ファイルサイズ超過: 413 Payload Too Large
+      next(new AppError(`ファイルサイズが上限（50MB）を超えています`, 413, 'FILE_TOO_LARGE'));
+    } else {
+      next(new AppError(`ファイルアップロードエラー: ${err.message}`, 400, 'UPLOAD_ERROR'));
+    }
+  } else {
+    next(err);
+  }
+}
+
+/**
+ * ファイルフィールド設定
+ * fields()を使用することで複数フィールドのファイルを一度に処理できる
+ */
+const uploadFields = upload.fields([
+  { name: 'bookFile', maxCount: 1 },    // 電子書籍ファイル（必須）
+  { name: 'coverImage', maxCount: 1 },  // 表紙画像（オプション）
+]);
+
+// ======= ルート定義 =======
+
+/**
+ * GET /api/books
+ * 書籍一覧取得
+ * author: 自分の書籍, admin: 全書籍
+ */
+router.get(
+  '/',
+  authenticate,
+  requireRole('author', 'admin'),
+  getBooks
+);
+
+/**
+ * POST /api/books
+ * 書籍新規登録（マルチパートファイルアップロード）
+ */
+router.post(
+  '/',
+  authenticate,
+  requireRole('author', 'admin'),
+  uploadFields,
+  multerErrorHandler,
+  [
+    // タイトルは必須（1〜200文字）
+    body('title')
+      .notEmpty().withMessage('タイトルは必須です')
+      .isLength({ max: 200 }).withMessage('タイトルは200文字以内で入力してください'),
+    // 説明はオプション
+    body('description')
+      .optional()
+      .isString().withMessage('説明は文字列で入力してください'),
+  ],
+  createBook
+);
+
+/**
+ * GET /api/books/:id
+ * 書籍詳細取得
+ */
+router.get(
+  '/:id',
+  authenticate,
+  requireRole('author', 'admin'),
+  [
+    param('id').isUUID().withMessage('書籍IDが不正です'),
+  ],
+  getBook
+);
+
+/**
+ * PUT /api/books/:id
+ * 書籍情報更新（ファイルの差し替えも可能）
+ */
+router.put(
+  '/:id',
+  authenticate,
+  requireRole('author', 'admin'),
+  uploadFields,
+  multerErrorHandler,
+  [
+    param('id').isUUID().withMessage('書籍IDが不正です'),
+    body('title')
+      .optional()
+      .notEmpty().withMessage('タイトルは空にできません')
+      .isLength({ max: 200 }).withMessage('タイトルは200文字以内で入力してください'),
+    body('description')
+      .optional()
+      .isString().withMessage('説明は文字列で入力してください'),
+  ],
+  updateBook
+);
+
+/**
+ * DELETE /api/books/:id
+ * 書籍削除（S3ファイルも合わせて削除）
+ */
+router.delete(
+  '/:id',
+  authenticate,
+  requireRole('author', 'admin'),
+  [
+    param('id').isUUID().withMessage('書籍IDが不正です'),
+  ],
+  deleteBook
+);
+
+export default router;

--- a/output_system/backend/src/routes/index.ts
+++ b/output_system/backend/src/routes/index.ts
@@ -8,6 +8,7 @@
 
 import { Router, Request, Response } from 'express';
 import authRouter from './auth.routes';
+import booksRouter from './books.routes';
 
 /**
  * メインAPIルーター
@@ -34,8 +35,10 @@ router.get('/health', (_req: Request, res: Response) => {
 // 認証APIルーターをマウント
 router.use('/auth', authRouter);
 
+// 書籍APIルーターをマウント
+router.use('/books', booksRouter);
+
 // TODO: 以下の各ルーターは後続のTaskで実装する
-// router.use('/books', booksRouter);
 // router.use('/signs', signsRouter);
 // router.use('/compose', composeRouter);
 // router.use('/fan', fanRouter);

--- a/output_system/backend/src/services/books.service.ts
+++ b/output_system/backend/src/services/books.service.ts
@@ -1,0 +1,393 @@
+/**
+ * @file books.service.ts
+ * @description 書籍ビジネスロジックサービス
+ *
+ * 書籍のCRUD操作に関するビジネスロジックを提供する。
+ * - ファイルのS3アップロード（AES-256暗号化）
+ * - 書籍メタデータのDB管理
+ * - 認可チェック（著者は自分の書籍のみ操作可）
+ *
+ * アップロード仕様:
+ * - 対応形式: PDF (application/pdf) / EPUB (application/epub+zip)
+ * - 最大ファイルサイズ: 50MB
+ * - S3キー形式: {uuid}/{originalFilename}（衝突回避）
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import path from 'path';
+import { BookModel, Book, CreateBookParams, UpdateBookParams } from '../models/book.model';
+import { storageService } from './storage.service';
+import { AppError, ForbiddenError, NotFoundError, ValidationError } from '../utils/errors';
+import { logger } from '../utils/logger';
+
+/**
+ * 書籍登録リクエストパラメータ
+ */
+export interface CreateBookInput {
+  /** 書籍タイトル（必須） */
+  title: string;
+  /** 書籍説明（オプション） */
+  description?: string;
+  /** アップロードされた電子書籍ファイル（multer Buffer） */
+  bookFile: Express.Multer.File;
+  /** アップロードされた表紙画像ファイル（multer Buffer、オプション） */
+  coverImageFile?: Express.Multer.File;
+  /** メタデータ（ISBN等、オプション） */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * 書籍更新リクエストパラメータ
+ */
+export interface UpdateBookInput {
+  /** 書籍タイトル */
+  title?: string;
+  /** 書籍説明 */
+  description?: string;
+  /** 新しい電子書籍ファイル（multer Buffer、オプション） */
+  bookFile?: Express.Multer.File;
+  /** 新しい表紙画像ファイル（multer Buffer、オプション） */
+  coverImageFile?: Express.Multer.File;
+  /** メタデータ */
+  metadata?: Record<string, unknown>;
+}
+
+/** 対応するMIMEタイプと対応する書籍形式のマッピング */
+const ALLOWED_BOOK_MIME_TYPES: Record<string, 'pdf' | 'epub'> = {
+  'application/pdf': 'pdf',
+  'application/epub+zip': 'epub',
+  // EPUBはブラウザによってMIMEタイプが異なる場合がある
+  'application/x-epub+zip': 'epub',
+};
+
+/** 対応するファイル拡張子 */
+const ALLOWED_BOOK_EXTENSIONS = ['.pdf', '.epub'];
+
+/**
+ * ファイル形式を検証してフォーマット文字列を返す
+ * MIMEタイプと拡張子の両方で検証する（一方のみの偽装を防ぐ）
+ *
+ * @param file - multerのファイルオブジェクト
+ * @returns 検証済みのフォーマット ('pdf' | 'epub')
+ * @throws {ValidationError} 対応していないファイル形式の場合
+ */
+function validateBookFileFormat(file: Express.Multer.File): 'pdf' | 'epub' {
+  // MIMEタイプで検証
+  const formatByMime = ALLOWED_BOOK_MIME_TYPES[file.mimetype];
+  if (!formatByMime) {
+    throw new ValidationError(
+      `対応していないファイル形式です。PDFまたはEPUBファイルをアップロードしてください。(MIMEタイプ: ${file.mimetype})`
+    );
+  }
+
+  // ファイル拡張子でも検証（MIMEタイプ偽装への二重チェック）
+  const ext = path.extname(file.originalname).toLowerCase();
+  if (!ALLOWED_BOOK_EXTENSIONS.includes(ext)) {
+    throw new ValidationError(
+      `対応していないファイル拡張子です。.pdf または .epub ファイルをアップロードしてください。(拡張子: ${ext})`
+    );
+  }
+
+  return formatByMime;
+}
+
+/**
+ * S3キーを生成する
+ * UUID/originalFilename 形式でファイル名の衝突を回避する
+ *
+ * @param originalname - 元のファイル名
+ * @returns S3ファイルキー
+ */
+function generateFileKey(originalname: string): string {
+  const uuid = uuidv4();
+  // ファイル名の特殊文字をサニタイズ（スペースやUnicode文字を除去）
+  const safeName = originalname.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return `${uuid}/${safeName}`;
+}
+
+/**
+ * S3サーバーサイド暗号化の設定を取得する
+ * - AWS S3本番環境: AES256（SSE-S3）
+ * - MinIO開発環境: KMS設定不要なためSSE無効（環境変数 S3_ENABLE_SSE=false で制御）
+ *
+ * MinIOでSSE-S3を使用するにはKMS設定が必要。
+ * 開発環境では S3_ENABLE_SSE=false（デフォルト無効）でスキップする。
+ *
+ * @returns サーバーサイド暗号化設定値、または無効の場合はundefined
+ */
+function getServerSideEncryption(): 'AES256' | undefined {
+  // S3_ENABLE_SSE=true の場合のみAES256暗号化を有効にする
+  // MinIOのデフォルト設定ではKMSが未設定のためSSEはサポートされない
+  return process.env.S3_ENABLE_SSE === 'true' ? 'AES256' : undefined;
+}
+
+/**
+ * 書籍ビジネスロジックサービスクラス
+ */
+export class BooksService {
+  /**
+   * 著者の書籍一覧を取得する
+   * adminの場合は全書籍を返す
+   *
+   * @param userId - リクエストユーザーID
+   * @param role - ユーザーロール
+   * @returns 書籍の配列
+   */
+  async getBooks(userId: string, role: string): Promise<Book[]> {
+    if (role === 'admin') {
+      return BookModel.findAll();
+    }
+    // authorは自分の書籍のみ
+    return BookModel.findByAuthorId(userId);
+  }
+
+  /**
+   * 書籍詳細を取得する
+   * 著者は自分の書籍のみ、adminは全書籍にアクセス可能
+   *
+   * @param bookId - 書籍ID
+   * @param userId - リクエストユーザーID
+   * @param role - ユーザーロール
+   * @returns 書籍オブジェクト
+   * @throws {NotFoundError} 書籍が存在しない場合
+   * @throws {ForbiddenError} 他の著者の書籍にアクセスしようとした場合
+   */
+  async getBook(bookId: string, userId: string, role: string): Promise<Book> {
+    const book = await BookModel.findById(bookId);
+    if (!book) {
+      throw new NotFoundError('書籍が見つかりません');
+    }
+
+    // adminは全書籍にアクセス可能、authorは自分の書籍のみ
+    if (role !== 'admin' && book.authorId !== userId) {
+      throw new ForbiddenError('この書籍にアクセスする権限がありません');
+    }
+
+    return book;
+  }
+
+  /**
+   * 書籍を新規登録する
+   * ファイルをS3にAES-256暗号化してアップロードし、メタデータをDBに保存する
+   *
+   * @param userId - 著者のユーザーID
+   * @param input - 書籍登録パラメータ
+   * @returns 作成した書籍オブジェクト
+   * @throws {ValidationError} ファイル形式や入力値が不正な場合
+   */
+  async createBook(userId: string, input: CreateBookInput): Promise<Book> {
+    // ファイル形式を検証
+    const format = validateBookFileFormat(input.bookFile);
+
+    // S3キーを生成してファイルをアップロード
+    const fileKey = generateFileKey(input.bookFile.originalname);
+    await storageService.upload({
+      key: fileKey,
+      body: input.bookFile.buffer,
+      contentType: input.bookFile.mimetype,
+      // AES-256でサーバーサイド暗号化（受入条件5: ファイルがS3に暗号化して保存される）
+      // MinIO開発環境ではKMS未設定のためS3_ENABLE_SSE=trueの場合のみ有効化
+      serverSideEncryption: getServerSideEncryption(),
+      metadata: {
+        originalName: input.bookFile.originalname,
+        authorId: userId,
+      },
+    });
+
+    logger.info('Book file uploaded to S3', { fileKey, authorId: userId });
+
+    // 表紙画像が指定されている場合はアップロード
+    let coverImageKey: string | undefined;
+    if (input.coverImageFile) {
+      coverImageKey = generateFileKey(input.coverImageFile.originalname);
+      await storageService.upload({
+        key: coverImageKey,
+        body: input.coverImageFile.buffer,
+        contentType: input.coverImageFile.mimetype,
+        serverSideEncryption: getServerSideEncryption(),
+        metadata: {
+          originalName: input.coverImageFile.originalname,
+          authorId: userId,
+          type: 'cover_image',
+        },
+      });
+      logger.info('Cover image uploaded to S3', { coverImageKey, authorId: userId });
+    }
+
+    // DBに書籍情報を保存
+    const createParams: CreateBookParams = {
+      authorId: userId,
+      title: input.title,
+      description: input.description,
+      format,
+      fileKey,
+      coverImageKey,
+      fileSize: input.bookFile.size,
+      metadata: input.metadata,
+    };
+
+    const book = await BookModel.create(createParams);
+    logger.info('Book created', { bookId: book.id, authorId: userId, format });
+
+    return book;
+  }
+
+  /**
+   * 書籍情報を更新する
+   * 著者は自分の書籍のみ更新可能
+   *
+   * @param bookId - 書籍ID
+   * @param userId - リクエストユーザーID
+   * @param role - ユーザーロール
+   * @param input - 更新パラメータ
+   * @returns 更新後の書籍オブジェクト
+   * @throws {NotFoundError} 書籍が存在しない場合
+   * @throws {ForbiddenError} 他の著者の書籍を更新しようとした場合
+   */
+  async updateBook(
+    bookId: string,
+    userId: string,
+    role: string,
+    input: UpdateBookInput
+  ): Promise<Book> {
+    // 書籍の存在と所有権を確認
+    const existingBook = await BookModel.findById(bookId);
+    if (!existingBook) {
+      throw new NotFoundError('書籍が見つかりません');
+    }
+
+    // authorは自分の書籍のみ更新可能
+    if (role !== 'admin' && existingBook.authorId !== userId) {
+      throw new ForbiddenError('この書籍を更新する権限がありません');
+    }
+
+    const updateParams: UpdateBookParams = {};
+
+    if (input.title !== undefined) updateParams.title = input.title;
+    if (input.description !== undefined) updateParams.description = input.description;
+    if (input.metadata !== undefined) updateParams.metadata = input.metadata;
+
+    // 新しいファイルが指定されている場合はS3にアップロード
+    if (input.bookFile) {
+      const format = validateBookFileFormat(input.bookFile);
+      const newFileKey = generateFileKey(input.bookFile.originalname);
+
+      await storageService.upload({
+        key: newFileKey,
+        body: input.bookFile.buffer,
+        contentType: input.bookFile.mimetype,
+        serverSideEncryption: getServerSideEncryption(),
+        metadata: {
+          originalName: input.bookFile.originalname,
+          authorId: userId,
+        },
+      });
+
+      // 古いファイルをS3から削除（ストレージの無駄遣いを防ぐ）
+      if (existingBook.fileKey) {
+        await storageService.delete(existingBook.fileKey).catch((err) => {
+          // 古いファイルの削除失敗は致命的ではないのでwarnとして記録
+          logger.warn('Failed to delete old book file', {
+            fileKey: existingBook.fileKey,
+            error: (err as Error).message,
+          });
+        });
+      }
+
+      updateParams.fileKey = newFileKey;
+      updateParams.fileSize = input.bookFile.size;
+      logger.info('Book file updated in S3', { newFileKey, bookId, format });
+    }
+
+    // 新しい表紙画像が指定されている場合はS3にアップロード
+    if (input.coverImageFile) {
+      const newCoverKey = generateFileKey(input.coverImageFile.originalname);
+
+      await storageService.upload({
+        key: newCoverKey,
+        body: input.coverImageFile.buffer,
+        contentType: input.coverImageFile.mimetype,
+        serverSideEncryption: getServerSideEncryption(),
+        metadata: {
+          originalName: input.coverImageFile.originalname,
+          authorId: userId,
+          type: 'cover_image',
+        },
+      });
+
+      // 古い表紙画像を削除
+      if (existingBook.coverImageKey) {
+        await storageService.delete(existingBook.coverImageKey).catch((err) => {
+          logger.warn('Failed to delete old cover image', {
+            coverImageKey: existingBook.coverImageKey,
+            error: (err as Error).message,
+          });
+        });
+      }
+
+      updateParams.coverImageKey = newCoverKey;
+      logger.info('Cover image updated in S3', { newCoverKey, bookId });
+    }
+
+    const updatedBook = await BookModel.update(bookId, updateParams);
+    if (!updatedBook) {
+      throw new AppError('書籍の更新に失敗しました', 500);
+    }
+
+    logger.info('Book updated', { bookId, authorId: userId });
+    return updatedBook;
+  }
+
+  /**
+   * 書籍を削除する
+   * S3のファイルも合わせて削除する
+   * authorは自分の書籍のみ削除可能
+   *
+   * @param bookId - 書籍ID
+   * @param userId - リクエストユーザーID
+   * @param role - ユーザーロール
+   * @throws {NotFoundError} 書籍が存在しない場合
+   * @throws {ForbiddenError} 他の著者の書籍を削除しようとした場合
+   */
+  async deleteBook(bookId: string, userId: string, role: string): Promise<void> {
+    // 書籍の存在と所有権を確認
+    const book = await BookModel.findById(bookId);
+    if (!book) {
+      throw new NotFoundError('書籍が見つかりません');
+    }
+
+    // authorは自分の書籍のみ削除可能
+    if (role !== 'admin' && book.authorId !== userId) {
+      throw new ForbiddenError('この書籍を削除する権限がありません');
+    }
+
+    // S3からファイルを削除（受入条件: DELETE /api/books/:id で書籍とS3ファイルが削除される）
+    if (book.fileKey) {
+      await storageService.delete(book.fileKey).catch((err) => {
+        logger.warn('Failed to delete book file from S3', {
+          fileKey: book.fileKey,
+          error: (err as Error).message,
+        });
+      });
+    }
+
+    // 表紙画像も削除
+    if (book.coverImageKey) {
+      await storageService.delete(book.coverImageKey).catch((err) => {
+        logger.warn('Failed to delete cover image from S3', {
+          coverImageKey: book.coverImageKey,
+          error: (err as Error).message,
+        });
+      });
+    }
+
+    // DBから書籍を削除
+    await BookModel.delete(bookId);
+    logger.info('Book deleted', { bookId, authorId: userId });
+  }
+}
+
+/**
+ * 書籍サービスのシングルトンインスタンス
+ */
+export const booksService = new BooksService();

--- a/output_system/backend/src/services/storage.service.ts
+++ b/output_system/backend/src/services/storage.service.ts
@@ -126,7 +126,9 @@ export class StorageService {
         Body: options.body,
         ContentType: options.contentType,
         // AES-256でサーバーサイド暗号化（機密データの保護）
-        ServerSideEncryption: options.serverSideEncryption || 'AES256',
+        // AES-256サーバーサイド暗号化: undefinedの場合は暗号化なし（MinIO開発環境ではKMS未設定のためSSE非対応）
+        // AWS S3本番環境では S3_ENABLE_SSE=true を設定して有効化すること
+        ServerSideEncryption: options.serverSideEncryption,
         Metadata: options.metadata,
       });
 

--- a/output_system/backend/test/services/books.service.test.ts
+++ b/output_system/backend/test/services/books.service.test.ts
@@ -1,0 +1,436 @@
+/**
+ * @file books.service.test.ts
+ * @description 書籍サービスのユニットテスト
+ *
+ * テスト対象:
+ * - BooksService.getBooks: 書籍一覧取得（author/adminのロール制御）
+ * - BooksService.getBook: 書籍詳細取得（所有権チェック）
+ * - BooksService.createBook: 書籍登録（ファイルアップロード・DB保存）
+ * - BooksService.updateBook: 書籍更新（所有権チェック・S3ファイル更新）
+ * - BooksService.deleteBook: 書籍削除（所有権チェック・S3ファイル削除）
+ *
+ * DBとS3操作はモック化してユニットテストとして実行する
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+// DBへの接続が発生しないようにモック化する
+jest.mock('../../src/config/database', () => ({
+  db: {
+    query: jest.fn(),
+    connect: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+// BookModelをモック化してDB接続不要にする
+jest.mock('../../src/models/book.model');
+
+// StorageServiceをモック化してS3接続不要にする
+jest.mock('../../src/services/storage.service');
+
+import { BooksService } from '../../src/services/books.service';
+import * as BookModelModule from '../../src/models/book.model';
+import { storageService } from '../../src/services/storage.service';
+import { Book } from '../../src/models/book.model';
+import { ForbiddenError, NotFoundError } from '../../src/utils/errors';
+
+/** テスト用の書籍データ */
+const mockBook: Book = {
+  id: 'book-id-1234',
+  authorId: 'author-user-id-1234',
+  title: 'テスト書籍',
+  description: 'テスト書籍の説明',
+  format: 'pdf',
+  fileKey: 'uuid-1234/test.pdf',
+  coverImageKey: 'uuid-5678/cover.jpg',
+  fileSize: 1024 * 1024, // 1MB
+  pageCount: null,
+  status: 'draft',
+  metadata: {},
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+/** テスト用のmulterファイルオブジェクト（PDF） */
+const mockPdfFile: Express.Multer.File = {
+  fieldname: 'bookFile',
+  originalname: 'test.pdf',
+  encoding: '7bit',
+  mimetype: 'application/pdf',
+  buffer: Buffer.from('fake pdf content'),
+  size: 1024 * 1024, // 1MB
+  stream: {} as never,
+  destination: '',
+  filename: '',
+  path: '',
+};
+
+/** テスト用のmulterファイルオブジェクト（EPUB） */
+const mockEpubFile: Express.Multer.File = {
+  fieldname: 'bookFile',
+  originalname: 'test.epub',
+  encoding: '7bit',
+  mimetype: 'application/epub+zip',
+  buffer: Buffer.from('fake epub content'),
+  size: 512 * 1024, // 512KB
+  stream: {} as never,
+  destination: '',
+  filename: '',
+  path: '',
+};
+
+/** テスト用の表紙画像ファイルオブジェクト */
+const mockCoverImageFile: Express.Multer.File = {
+  fieldname: 'coverImage',
+  originalname: 'cover.jpg',
+  encoding: '7bit',
+  mimetype: 'image/jpeg',
+  buffer: Buffer.from('fake jpg content'),
+  size: 256 * 1024, // 256KB
+  stream: {} as never,
+  destination: '',
+  filename: '',
+  path: '',
+};
+
+describe('BooksService', () => {
+  let booksService: BooksService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    booksService = new BooksService();
+  });
+
+  /**
+   * 【テスト対象】getBooks
+   * 【テスト内容】authorロールでgetBooksを呼び出した場合
+   * 【期待結果】findByAuthorIdが自分のuserIdで呼び出される
+   */
+  describe('getBooks', () => {
+    it('should call findByAuthorId for author role', async () => {
+      const mockBooks = [mockBook];
+      const mockFindByAuthorId = jest.spyOn(BookModelModule.BookModel, 'findByAuthorId')
+        .mockResolvedValue(mockBooks);
+
+      const result = await booksService.getBooks('author-user-id-1234', 'author');
+
+      expect(mockFindByAuthorId).toHaveBeenCalledWith('author-user-id-1234');
+      expect(result).toEqual(mockBooks);
+    });
+
+    /**
+     * 【テスト対象】getBooks
+     * 【テスト内容】adminロールでgetBooksを呼び出した場合
+     * 【期待結果】findAllが呼び出される（全書籍取得）
+     */
+    it('should call findAll for admin role', async () => {
+      const mockBooks = [mockBook];
+      const mockFindAll = jest.spyOn(BookModelModule.BookModel, 'findAll')
+        .mockResolvedValue(mockBooks);
+
+      const result = await booksService.getBooks('admin-user-id', 'admin');
+
+      expect(mockFindAll).toHaveBeenCalled();
+      expect(result).toEqual(mockBooks);
+    });
+  });
+
+  /**
+   * 【テスト対象】getBook
+   * 【テスト内容】著者が自分の書籍を取得する場合
+   * 【期待結果】書籍オブジェクトが返される
+   */
+  describe('getBook', () => {
+    it('should return book for author accessing own book', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+
+      const result = await booksService.getBook('book-id-1234', 'author-user-id-1234', 'author');
+
+      expect(result).toEqual(mockBook);
+    });
+
+    /**
+     * 【テスト対象】getBook
+     * 【テスト内容】著者が他者の書籍を取得しようとした場合
+     * 【期待結果】ForbiddenError (403) がスローされる
+     */
+    it('should throw ForbiddenError when author accesses other authors book', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+
+      await expect(
+        booksService.getBook('book-id-1234', 'different-author-id', 'author')
+      ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    /**
+     * 【テスト対象】getBook
+     * 【テスト内容】adminが任意の書籍を取得する場合
+     * 【期待結果】書籍オブジェクトが返される（認可チェックなし）
+     */
+    it('should return book for admin accessing any book', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+
+      const result = await booksService.getBook('book-id-1234', 'admin-user-id', 'admin');
+
+      expect(result).toEqual(mockBook);
+    });
+
+    /**
+     * 【テスト対象】getBook
+     * 【テスト内容】存在しない書籍IDを指定した場合
+     * 【期待結果】NotFoundError (404) がスローされる
+     */
+    it('should throw NotFoundError when book does not exist', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(null);
+
+      await expect(
+        booksService.getBook('non-existent-id', 'author-user-id-1234', 'author')
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+  });
+
+  /**
+   * 【テスト対象】createBook
+   * 【テスト内容】PDFファイルで書籍を登録する場合
+   * 【期待結果】
+   * - storageService.uploadが呼び出される
+   * - BookModel.createが呼び出される
+   * - 作成された書籍オブジェクトが返される
+   */
+  describe('createBook', () => {
+    it('should create book with PDF file', async () => {
+      const mockStorageUpload = jest.spyOn(storageService, 'upload').mockResolvedValue('uuid/test.pdf');
+      const mockBookCreate = jest.spyOn(BookModelModule.BookModel, 'create').mockResolvedValue(mockBook);
+
+      const result = await booksService.createBook('author-user-id-1234', {
+        title: 'テスト書籍',
+        description: 'テスト説明',
+        bookFile: mockPdfFile,
+      });
+
+      expect(mockStorageUpload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: mockPdfFile.buffer,
+          contentType: 'application/pdf',
+          serverSideEncryption: 'AES256',
+        })
+      );
+      expect(mockBookCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorId: 'author-user-id-1234',
+          title: 'テスト書籍',
+          format: 'pdf',
+        })
+      );
+      expect(result).toEqual(mockBook);
+    });
+
+    /**
+     * 【テスト対象】createBook
+     * 【テスト内容】EPUBファイルで書籍を登録する場合
+     * 【期待結果】formatが 'epub' としてDBに保存される
+     */
+    it('should create book with EPUB file and set format to epub', async () => {
+      const mockEpubBook = { ...mockBook, format: 'epub' as const };
+      jest.spyOn(storageService, 'upload').mockResolvedValue('uuid/test.epub');
+      const mockBookCreate = jest.spyOn(BookModelModule.BookModel, 'create')
+        .mockResolvedValue(mockEpubBook);
+
+      const result = await booksService.createBook('author-user-id-1234', {
+        title: 'テストEPUB書籍',
+        bookFile: mockEpubFile,
+      });
+
+      expect(mockBookCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ format: 'epub' })
+      );
+      expect(result.format).toBe('epub');
+    });
+
+    /**
+     * 【テスト対象】createBook
+     * 【テスト内容】表紙画像ありで書籍を登録する場合
+     * 【期待結果】storageService.uploadが2回（書籍ファイル + 表紙画像）呼び出される
+     */
+    it('should upload both book file and cover image when cover is provided', async () => {
+      const mockStorageUpload = jest.spyOn(storageService, 'upload').mockResolvedValue('uuid/file');
+      jest.spyOn(BookModelModule.BookModel, 'create').mockResolvedValue(mockBook);
+
+      await booksService.createBook('author-user-id-1234', {
+        title: 'テスト書籍',
+        bookFile: mockPdfFile,
+        coverImageFile: mockCoverImageFile,
+      });
+
+      // 書籍ファイルと表紙画像の2回アップロードされることを確認
+      expect(mockStorageUpload).toHaveBeenCalledTimes(2);
+    });
+
+    /**
+     * 【テスト対象】createBook
+     * 【テスト内容】不正なMIMEタイプのファイルを登録しようとした場合
+     * 【期待結果】ValidationError (400) がスローされる
+     */
+    it('should throw ValidationError for invalid file type', async () => {
+      const invalidFile: Express.Multer.File = {
+        ...mockPdfFile,
+        mimetype: 'image/jpeg',
+        originalname: 'test.jpg',
+      };
+
+      await expect(
+        booksService.createBook('author-user-id-1234', {
+          title: 'テスト書籍',
+          bookFile: invalidFile,
+        })
+      ).rejects.toThrow(expect.objectContaining({ statusCode: 400 }));
+    });
+
+    /**
+     * 【テスト対象】createBook
+     * 【テスト内容】MIMEタイプはPDFだがファイル拡張子が不正な場合
+     * 【期待結果】ValidationError (400) がスローされる（二重チェック）
+     */
+    it('should throw ValidationError when extension does not match MIME type', async () => {
+      const mismatchedFile: Express.Multer.File = {
+        ...mockPdfFile,
+        mimetype: 'application/pdf',
+        originalname: 'test.exe', // 不正な拡張子
+      };
+
+      await expect(
+        booksService.createBook('author-user-id-1234', {
+          title: 'テスト書籍',
+          bookFile: mismatchedFile,
+        })
+      ).rejects.toThrow(expect.objectContaining({ statusCode: 400 }));
+    });
+  });
+
+  /**
+   * 【テスト対象】updateBook
+   * 【テスト内容】著者が自分の書籍を更新する場合
+   * 【期待結果】BookModel.updateが呼び出されて更新後の書籍が返される
+   */
+  describe('updateBook', () => {
+    it('should update book for author accessing own book', async () => {
+      const updatedBook = { ...mockBook, title: '更新後タイトル' };
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+      const mockUpdate = jest.spyOn(BookModelModule.BookModel, 'update').mockResolvedValue(updatedBook);
+
+      const result = await booksService.updateBook(
+        'book-id-1234',
+        'author-user-id-1234',
+        'author',
+        { title: '更新後タイトル' }
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith('book-id-1234', expect.objectContaining({ title: '更新後タイトル' }));
+      expect(result.title).toBe('更新後タイトル');
+    });
+
+    /**
+     * 【テスト対象】updateBook
+     * 【テスト内容】著者が他者の書籍を更新しようとした場合
+     * 【期待結果】ForbiddenError (403) がスローされる
+     */
+    it('should throw ForbiddenError when author tries to update other authors book', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+
+      await expect(
+        booksService.updateBook(
+          'book-id-1234',
+          'different-author-id',
+          'author',
+          { title: '更新後タイトル' }
+        )
+      ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    /**
+     * 【テスト対象】updateBook
+     * 【テスト内容】新しいファイルを指定して更新する場合
+     * 【期待結果】新しいファイルがS3にアップロードされ、古いファイルが削除される
+     */
+    it('should upload new file and delete old file when bookFile is provided', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+      jest.spyOn(BookModelModule.BookModel, 'update').mockResolvedValue(mockBook);
+      const mockUpload = jest.spyOn(storageService, 'upload').mockResolvedValue('new-uuid/test.pdf');
+      const mockDelete = jest.spyOn(storageService, 'delete').mockResolvedValue();
+
+      await booksService.updateBook(
+        'book-id-1234',
+        'author-user-id-1234',
+        'author',
+        { bookFile: mockPdfFile }
+      );
+
+      expect(mockUpload).toHaveBeenCalledTimes(1);
+      // 古いfileKeyが削除されることを確認
+      expect(mockDelete).toHaveBeenCalledWith(mockBook.fileKey);
+    });
+  });
+
+  /**
+   * 【テスト対象】deleteBook
+   * 【テスト内容】著者が自分の書籍を削除する場合
+   * 【期待結果】BookModel.deleteとstorageService.deleteが呼び出される
+   */
+  describe('deleteBook', () => {
+    it('should delete book and S3 files for author', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+      const mockDelete = jest.spyOn(BookModelModule.BookModel, 'delete').mockResolvedValue(true);
+      const mockStorageDelete = jest.spyOn(storageService, 'delete').mockResolvedValue();
+
+      await booksService.deleteBook('book-id-1234', 'author-user-id-1234', 'author');
+
+      expect(mockDelete).toHaveBeenCalledWith('book-id-1234');
+      // fileKeyとcoverImageKeyの両方が削除されることを確認
+      expect(mockStorageDelete).toHaveBeenCalledWith(mockBook.fileKey);
+      expect(mockStorageDelete).toHaveBeenCalledWith(mockBook.coverImageKey);
+    });
+
+    /**
+     * 【テスト対象】deleteBook
+     * 【テスト内容】著者が他者の書籍を削除しようとした場合
+     * 【期待結果】ForbiddenError (403) がスローされる
+     */
+    it('should throw ForbiddenError when author tries to delete other authors book', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+
+      await expect(
+        booksService.deleteBook('book-id-1234', 'different-author-id', 'author')
+      ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    /**
+     * 【テスト対象】deleteBook
+     * 【テスト内容】存在しない書籍を削除しようとした場合
+     * 【期待結果】NotFoundError (404) がスローされる
+     */
+    it('should throw NotFoundError when book does not exist', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(null);
+
+      await expect(
+        booksService.deleteBook('non-existent-id', 'author-user-id-1234', 'author')
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    /**
+     * 【テスト対象】deleteBook
+     * 【テスト内容】adminが任意の書籍を削除する場合
+     * 【期待結果】認可エラーなしで削除される
+     */
+    it('should allow admin to delete any book', async () => {
+      jest.spyOn(BookModelModule.BookModel, 'findById').mockResolvedValue(mockBook);
+      const mockDelete = jest.spyOn(BookModelModule.BookModel, 'delete').mockResolvedValue(true);
+      jest.spyOn(storageService, 'delete').mockResolvedValue();
+
+      await booksService.deleteBook('book-id-1234', 'admin-user-id', 'admin');
+
+      expect(mockDelete).toHaveBeenCalledWith('book-id-1234');
+    });
+  });
+});

--- a/output_system/backend/test/services/books.service.test.ts
+++ b/output_system/backend/test/services/books.service.test.ts
@@ -214,7 +214,9 @@ describe('BooksService', () => {
         expect.objectContaining({
           body: mockPdfFile.buffer,
           contentType: 'application/pdf',
-          serverSideEncryption: 'AES256',
+          // serverSideEncryptionはS3_ENABLE_SSE=trueの場合のみ'AES256'、デフォルトはundefined
+          // テスト環境ではS3_ENABLE_SSE未設定のためundefinedになる
+          serverSideEncryption: undefined,
         })
       );
       expect(mockBookCreate).toHaveBeenCalledWith(

--- a/output_system/frontend/next.config.js
+++ b/output_system/frontend/next.config.js
@@ -30,17 +30,28 @@ const nextConfig = {
     const backendUrl = process.env.BACKEND_URL
       || 'http://okegawaatclink-gaido-signia-output-system-backend:3002';
 
-    return [
-      {
-        // /api/auth/* はNextAuth.jsが処理するためプロキシしない（除外設定）
-        // このルールより前にNextAuth.jsのルートがマッチするため、プロキシから除外される
-        // /api/* のリクエストをバックエンドの /api/* にプロキシ
-        // ただし /api/auth/* はNextAuth.jsのルートハンドラーが先にキャッチするため
-        // 実際にはバックエンドにはプロキシされない
-        source: '/api/:path((?!auth/).*)',
-        destination: `${backendUrl}/api/:path*`,
-      },
-    ];
+    return {
+      // beforeFiles: Next.jsのルートハンドラーより前に評価されるrewrite
+      // /api/auth/[...nextauth] (NextAuth.js) より先にバックエンドAPIエンドポイントをプロキシする
+      beforeFiles: [
+        // バックエンドの認証APIエンドポイントを明示的にプロキシする
+        // /api/auth/login, /api/auth/logout, /api/auth/me, /api/auth/oauth はバックエンドに転送
+        // Note: beforeFilesを使うことでNextAuth.jsのルートハンドラーより先にマッチさせる
+        { source: '/api/auth/login', destination: `${backendUrl}/api/auth/login` },
+        { source: '/api/auth/logout', destination: `${backendUrl}/api/auth/logout` },
+        { source: '/api/auth/me', destination: `${backendUrl}/api/auth/me` },
+        { source: '/api/auth/oauth', destination: `${backendUrl}/api/auth/oauth` },
+      ],
+      // afterFiles: /api/auth/* 以外の全APIをバックエンドにプロキシ
+      afterFiles: [
+        {
+          // /api/auth/[...nextauth] はNextAuth.jsが処理するためプロキシ除外
+          // それ以外の /api/* はバックエンドにプロキシ
+          source: '/api/:path((?!auth/).*)',
+          destination: `${backendUrl}/api/:path*`,
+        },
+      ],
+    };
   },
 };
 

--- a/output_system/frontend/src/app/author/books/new/page.tsx
+++ b/output_system/frontend/src/app/author/books/new/page.tsx
@@ -1,0 +1,740 @@
+/**
+ * @file author/books/new/page.tsx
+ * @description 書籍登録画面
+ *
+ * 著者がPDF/EPUBファイルをアップロードしてメタデータとともに書籍を登録する画面。
+ *
+ * 機能:
+ * - ファイルアップロードUI（ドラッグ&ドロップ対応）
+ * - PDF/EPUB形式バリデーション（クライアントサイド）
+ * - ファイルサイズ表示（50MB制限）
+ * - 表紙画像アップロード（オプション）
+ * - アップロード進捗表示
+ * - 登録完了後に書籍一覧画面にリダイレクト
+ */
+
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { getToken, apiGetMe, apiCreateBook, AuthUser, ApiError } from '../../../../lib/api';
+
+/**
+ * ファイルサイズを人間が読みやすい形式に変換する
+ * 例: 1048576 → "1.0 MB"
+ *
+ * @param bytes - バイト数
+ * @returns フォーマットされたファイルサイズ文字列
+ */
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** 書籍ファイルの最大サイズ（50MB） */
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+
+/** 許可する書籍ファイルのMIMEタイプ */
+const ALLOWED_BOOK_MIME_TYPES = ['application/pdf', 'application/epub+zip', 'application/x-epub+zip'];
+
+/** 許可する書籍ファイルの拡張子 */
+const ALLOWED_BOOK_EXTENSIONS = ['.pdf', '.epub'];
+
+/**
+ * 書籍登録画面コンポーネント
+ *
+ * @returns {JSX.Element} 書籍登録フォーム
+ */
+export default function NewBookPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+  // フォームの状態
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [isbn, setIsbn] = useState('');
+
+  // ファイルの状態
+  const [bookFile, setBookFile] = useState<File | null>(null);
+  const [coverImageFile, setCoverImageFile] = useState<File | null>(null);
+  const [coverImagePreview, setCoverImagePreview] = useState<string | null>(null);
+
+  // UI状態
+  const [isDragging, setIsDragging] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // ファイル入力のref
+  const bookFileInputRef = useRef<HTMLInputElement>(null);
+  const coverImageInputRef = useRef<HTMLInputElement>(null);
+
+  // マウント時に認証状態を確認する
+  useEffect(() => {
+    async function checkAuth() {
+      const token = getToken();
+      if (!token) {
+        router.push('/admin/login');
+        return;
+      }
+      try {
+        const result = await apiGetMe();
+        if (result.user.role !== 'author') {
+          router.push('/admin/login');
+          return;
+        }
+        setUser(result.user);
+      } catch {
+        router.push('/admin/login');
+      } finally {
+        setIsAuthLoading(false);
+      }
+    }
+    checkAuth();
+  }, [router]);
+
+  /**
+   * 書籍ファイルを検証する（クライアントサイドバリデーション）
+   * - MIMEタイプと拡張子の両方を確認する
+   * - ファイルサイズが50MBを超えていないか確認する
+   *
+   * @param file - 検証するファイル
+   * @returns エラーメッセージ、またはnull（検証OK）
+   */
+  function validateBookFile(file: File): string | null {
+    // MIMEタイプ検証
+    if (!ALLOWED_BOOK_MIME_TYPES.includes(file.type)) {
+      return `対応していないファイル形式です。PDFまたはEPUBファイルを選択してください。(${file.type})`;
+    }
+    // 拡張子検証
+    const ext = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
+    if (!ALLOWED_BOOK_EXTENSIONS.includes(ext)) {
+      return `対応していない拡張子です。.pdf または .epub ファイルを選択してください。`;
+    }
+    // サイズ検証
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return `ファイルサイズが上限（50MB）を超えています。（現在: ${formatFileSize(file.size)}）`;
+    }
+    return null;
+  }
+
+  /**
+   * 書籍ファイルをセットする
+   * バリデーションを行い、エラーがあればエラーメッセージを表示する
+   *
+   * @param file - セットするファイル
+   */
+  function handleBookFileSelect(file: File) {
+    const error = validateBookFile(file);
+    if (error) {
+      setFileError(error);
+      setBookFile(null);
+    } else {
+      setFileError(null);
+      setBookFile(file);
+    }
+  }
+
+  /**
+   * ドラッグオーバー時のイベントハンドラー
+   * ドラッグ中にドロップゾーンのスタイルを変更する
+   */
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  }, []);
+
+  /**
+   * ドラッグリーブ時のイベントハンドラー
+   */
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  }, []);
+
+  /**
+   * ドロップ時のイベントハンドラー
+   * ドロップされたファイルをバリデーションしてセットする
+   */
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length === 0) return;
+
+    handleBookFileSelect(files[0]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /**
+   * ファイル選択ダイアログからのファイル選択ハンドラー
+   */
+  function handleFileInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      handleBookFileSelect(file);
+    }
+  }
+
+  /**
+   * 表紙画像選択ハンドラー
+   * 選択した画像のプレビューを表示する
+   */
+  function handleCoverImageChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setCoverImageFile(file);
+
+    // プレビュー用のURL生成（FileReader APIを使用）
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setCoverImagePreview(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  }
+
+  /**
+   * 書籍ファイルをクリアする
+   */
+  function handleClearBookFile() {
+    setBookFile(null);
+    setFileError(null);
+    if (bookFileInputRef.current) {
+      bookFileInputRef.current.value = '';
+    }
+  }
+
+  /**
+   * 表紙画像をクリアする
+   */
+  function handleClearCoverImage() {
+    setCoverImageFile(null);
+    setCoverImagePreview(null);
+    if (coverImageInputRef.current) {
+      coverImageInputRef.current.value = '';
+    }
+  }
+
+  /**
+   * フォーム送信ハンドラー
+   * FormDataを作成してAPIに送信する
+   * アップロード中はボタンを無効化してダブルクリックを防止する
+   */
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!bookFile) {
+      setFileError('電子書籍ファイルを選択してください');
+      return;
+    }
+
+    if (!title.trim()) {
+      setSubmitError('タイトルを入力してください');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    // 進捗を擬似的に表示（fetchはXHRと異なりネイティブな進捗イベントが不可）
+    // アップロード中はユーザーに視覚的なフィードバックを与えるため擬似進捗を表示する
+    const progressInterval = setInterval(() => {
+      setUploadProgress((prev) => {
+        // 90%まで段階的に進める（100%は完了時にセット）
+        if (prev < 90) {
+          return Math.min(prev + Math.random() * 15, 90);
+        }
+        return prev;
+      });
+    }, 300);
+
+    try {
+      const formData = new FormData();
+      formData.append('title', title.trim());
+      if (description.trim()) {
+        formData.append('description', description.trim());
+      }
+      // 電子書籍ファイル（必須）
+      formData.append('bookFile', bookFile, bookFile.name);
+      // 表紙画像（オプション）
+      if (coverImageFile) {
+        formData.append('coverImage', coverImageFile, coverImageFile.name);
+      }
+      // メタデータ（ISBNが入力されている場合）
+      if (isbn.trim()) {
+        formData.append('metadata', JSON.stringify({ isbn: isbn.trim() }));
+      }
+
+      await apiCreateBook(formData);
+
+      setUploadProgress(100);
+
+      // 登録完了後に書籍一覧画面にリダイレクト
+      setTimeout(() => {
+        router.push('/author/books');
+      }, 500);
+    } catch (error) {
+      const apiError = error as ApiError;
+      setSubmitError(apiError.message || '書籍の登録に失敗しました');
+      setUploadProgress(0);
+    } finally {
+      clearInterval(progressInterval);
+      setIsSubmitting(false);
+    }
+  }
+
+  if (isAuthLoading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+        <p>読み込み中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', backgroundColor: '#f9fafb' }}>
+      {/* ヘッダー */}
+      <header style={{
+        backgroundColor: '#fff',
+        borderBottom: '1px solid #e5e7eb',
+        padding: '1rem 2rem',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          <button
+            onClick={() => router.push('/author/books')}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: '#6b7280',
+              fontSize: '1.2rem',
+              padding: '0.25rem',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+            aria-label="書籍一覧に戻る"
+          >
+            ←
+          </button>
+          <h1 style={{ fontSize: '1.25rem', fontWeight: '600', color: '#111827' }}>
+            書籍登録
+          </h1>
+        </div>
+        <span style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+          {user?.name}（著者）
+        </span>
+      </header>
+
+      {/* メインコンテンツ */}
+      <main style={{ maxWidth: '800px', margin: '0 auto', padding: '2rem' }}>
+        <form onSubmit={handleSubmit}>
+          {/* ファイルアップロードセクション */}
+          <section style={{
+            backgroundColor: '#fff',
+            borderRadius: '12px',
+            padding: '1.5rem',
+            marginBottom: '1.5rem',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+          }}>
+            <h2 style={{ fontSize: '1rem', fontWeight: '600', color: '#374151', marginBottom: '1rem' }}>
+              電子書籍ファイル <span style={{ color: '#ef4444' }}>*</span>
+            </h2>
+
+            {/* ドロップゾーン */}
+            {!bookFile ? (
+              <div
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                onClick={() => bookFileInputRef.current?.click()}
+                style={{
+                  border: `2px dashed ${isDragging ? '#2563eb' : fileError ? '#ef4444' : '#d1d5db'}`,
+                  borderRadius: '8px',
+                  padding: '3rem 2rem',
+                  textAlign: 'center',
+                  cursor: 'pointer',
+                  backgroundColor: isDragging ? '#eff6ff' : '#f9fafb',
+                  transition: 'all 0.2s',
+                }}
+                role="button"
+                aria-label="ファイルをドラッグ&ドロップまたはクリックして選択"
+                tabIndex={0}
+                onKeyDown={(e) => e.key === 'Enter' && bookFileInputRef.current?.click()}
+              >
+                <div style={{ fontSize: '2.5rem', marginBottom: '0.75rem' }}>📄</div>
+                <p style={{ fontSize: '1rem', color: '#374151', marginBottom: '0.5rem', fontWeight: '500' }}>
+                  ここにファイルをドラッグ&ドロップ
+                </p>
+                <p style={{ fontSize: '0.875rem', color: '#6b7280', marginBottom: '0.75rem' }}>
+                  または
+                </p>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    bookFileInputRef.current?.click();
+                  }}
+                  style={{
+                    padding: '0.5rem 1.25rem',
+                    backgroundColor: '#2563eb',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: '6px',
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                    fontWeight: '500',
+                  }}
+                >
+                  ファイルを選択
+                </button>
+                <p style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '1rem' }}>
+                  対応形式: PDF, EPUB（最大50MB）
+                </p>
+              </div>
+            ) : (
+              /* 選択されたファイルの表示 */
+              <div style={{
+                border: '1px solid #d1d5db',
+                borderRadius: '8px',
+                padding: '1rem',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                backgroundColor: '#f0fdf4',
+              }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                  <span style={{ fontSize: '1.5rem' }}>
+                    {bookFile.name.endsWith('.pdf') ? '📕' : '📗'}
+                  </span>
+                  <div>
+                    <p style={{ fontSize: '0.875rem', fontWeight: '500', color: '#111827' }}>
+                      {bookFile.name}
+                    </p>
+                    <p style={{ fontSize: '0.75rem', color: '#6b7280' }}>
+                      {formatFileSize(bookFile.size)} • {bookFile.name.endsWith('.pdf') ? 'PDF' : 'EPUB'}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleClearBookFile}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#6b7280',
+                    fontSize: '1.2rem',
+                    padding: '0.25rem',
+                  }}
+                  aria-label="ファイルを削除"
+                >
+                  ✕
+                </button>
+              </div>
+            )}
+
+            {/* ファイルエラー表示 */}
+            {fileError && (
+              <p style={{ color: '#ef4444', fontSize: '0.875rem', marginTop: '0.5rem' }}>
+                {fileError}
+              </p>
+            )}
+
+            {/* 隠しファイル入力 */}
+            <input
+              ref={bookFileInputRef}
+              type="file"
+              accept=".pdf,.epub"
+              onChange={handleFileInputChange}
+              style={{ display: 'none' }}
+              aria-hidden="true"
+            />
+          </section>
+
+          {/* メタデータセクション */}
+          <section style={{
+            backgroundColor: '#fff',
+            borderRadius: '12px',
+            padding: '1.5rem',
+            marginBottom: '1.5rem',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+          }}>
+            <h2 style={{ fontSize: '1rem', fontWeight: '600', color: '#374151', marginBottom: '1rem' }}>
+              書籍情報
+            </h2>
+
+            {/* タイトル入力 */}
+            <div style={{ marginBottom: '1rem' }}>
+              <label
+                htmlFor="title"
+                style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: '#374151', marginBottom: '0.5rem' }}
+              >
+                タイトル <span style={{ color: '#ef4444' }}>*</span>
+              </label>
+              <input
+                id="title"
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="書籍のタイトルを入力してください"
+                maxLength={200}
+                required
+                style={{
+                  width: '100%',
+                  padding: '0.625rem 0.875rem',
+                  border: '1px solid #d1d5db',
+                  borderRadius: '6px',
+                  fontSize: '0.875rem',
+                  color: '#111827',
+                  backgroundColor: '#fff',
+                  outline: 'none',
+                  boxSizing: 'border-box',
+                }}
+              />
+              <p style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '0.25rem' }}>
+                {title.length}/200文字
+              </p>
+            </div>
+
+            {/* 説明入力 */}
+            <div style={{ marginBottom: '1rem' }}>
+              <label
+                htmlFor="description"
+                style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: '#374151', marginBottom: '0.5rem' }}
+              >
+                書籍説明
+              </label>
+              <textarea
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="書籍の内容や概要を入力してください（オプション）"
+                rows={4}
+                style={{
+                  width: '100%',
+                  padding: '0.625rem 0.875rem',
+                  border: '1px solid #d1d5db',
+                  borderRadius: '6px',
+                  fontSize: '0.875rem',
+                  color: '#111827',
+                  backgroundColor: '#fff',
+                  outline: 'none',
+                  resize: 'vertical',
+                  boxSizing: 'border-box',
+                }}
+              />
+            </div>
+
+            {/* ISBN入力 */}
+            <div>
+              <label
+                htmlFor="isbn"
+                style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: '#374151', marginBottom: '0.5rem' }}
+              >
+                ISBN（オプション）
+              </label>
+              <input
+                id="isbn"
+                type="text"
+                value={isbn}
+                onChange={(e) => setIsbn(e.target.value)}
+                placeholder="978-4-xxxx-xxxx-x"
+                style={{
+                  width: '100%',
+                  padding: '0.625rem 0.875rem',
+                  border: '1px solid #d1d5db',
+                  borderRadius: '6px',
+                  fontSize: '0.875rem',
+                  color: '#111827',
+                  backgroundColor: '#fff',
+                  outline: 'none',
+                  boxSizing: 'border-box',
+                }}
+              />
+            </div>
+          </section>
+
+          {/* 表紙画像セクション */}
+          <section style={{
+            backgroundColor: '#fff',
+            borderRadius: '12px',
+            padding: '1.5rem',
+            marginBottom: '1.5rem',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+          }}>
+            <h2 style={{ fontSize: '1rem', fontWeight: '600', color: '#374151', marginBottom: '1rem' }}>
+              表紙画像（オプション）
+            </h2>
+
+            <div style={{ display: 'flex', gap: '1rem', alignItems: 'flex-start' }}>
+              {/* 表紙画像プレビュー */}
+              <div style={{
+                width: '120px',
+                height: '160px',
+                border: '1px dashed #d1d5db',
+                borderRadius: '6px',
+                overflow: 'hidden',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: '#f9fafb',
+                flexShrink: 0,
+              }}>
+                {coverImagePreview ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={coverImagePreview}
+                    alt="表紙画像プレビュー"
+                    style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                  />
+                ) : (
+                  <span style={{ fontSize: '2rem' }}>🖼️</span>
+                )}
+              </div>
+
+              <div style={{ flex: 1 }}>
+                <input
+                  ref={coverImageInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={handleCoverImageChange}
+                  style={{ display: 'none' }}
+                  aria-hidden="true"
+                />
+                <button
+                  type="button"
+                  onClick={() => coverImageInputRef.current?.click()}
+                  style={{
+                    padding: '0.5rem 1rem',
+                    border: '1px solid #d1d5db',
+                    borderRadius: '6px',
+                    backgroundColor: '#fff',
+                    color: '#374151',
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                    marginBottom: '0.5rem',
+                    display: 'block',
+                  }}
+                >
+                  画像を選択
+                </button>
+                {coverImageFile && (
+                  <div>
+                    <p style={{ fontSize: '0.75rem', color: '#6b7280', marginBottom: '0.25rem' }}>
+                      {coverImageFile.name} ({formatFileSize(coverImageFile.size)})
+                    </p>
+                    <button
+                      type="button"
+                      onClick={handleClearCoverImage}
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: '#ef4444',
+                        fontSize: '0.75rem',
+                        padding: '0',
+                      }}
+                    >
+                      削除
+                    </button>
+                  </div>
+                )}
+                <p style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '0.5rem' }}>
+                  対応形式: JPEG, PNG, WebP
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* アップロード進捗表示 */}
+          {isSubmitting && (
+            <div style={{ marginBottom: '1.5rem' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.25rem' }}>
+                <span style={{ fontSize: '0.875rem', color: '#374151' }}>アップロード中...</span>
+                <span style={{ fontSize: '0.875rem', color: '#374151' }}>{Math.round(uploadProgress)}%</span>
+              </div>
+              <div style={{
+                height: '8px',
+                backgroundColor: '#e5e7eb',
+                borderRadius: '4px',
+                overflow: 'hidden',
+              }}>
+                <div style={{
+                  height: '100%',
+                  backgroundColor: '#2563eb',
+                  borderRadius: '4px',
+                  width: `${uploadProgress}%`,
+                  transition: 'width 0.3s ease',
+                }} />
+              </div>
+            </div>
+          )}
+
+          {/* エラー表示 */}
+          {submitError && (
+            <div style={{
+              backgroundColor: '#fef2f2',
+              border: '1px solid #fecaca',
+              borderRadius: '6px',
+              padding: '0.75rem 1rem',
+              marginBottom: '1rem',
+              color: '#991b1b',
+              fontSize: '0.875rem',
+            }}>
+              {submitError}
+            </div>
+          )}
+
+          {/* 送信ボタン */}
+          <div style={{ display: 'flex', gap: '1rem', justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={() => router.push('/author/books')}
+              disabled={isSubmitting}
+              style={{
+                padding: '0.625rem 1.5rem',
+                border: '1px solid #d1d5db',
+                borderRadius: '8px',
+                backgroundColor: '#fff',
+                color: '#374151',
+                cursor: isSubmitting ? 'not-allowed' : 'pointer',
+                fontSize: '0.875rem',
+                fontWeight: '500',
+                opacity: isSubmitting ? 0.6 : 1,
+              }}
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting || !bookFile || !title.trim()}
+              style={{
+                padding: '0.625rem 1.5rem',
+                backgroundColor: isSubmitting || !bookFile || !title.trim() ? '#93c5fd' : '#2563eb',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '8px',
+                cursor: isSubmitting || !bookFile || !title.trim() ? 'not-allowed' : 'pointer',
+                fontSize: '0.875rem',
+                fontWeight: '500',
+              }}
+            >
+              {isSubmitting ? '登録中...' : '書籍を登録する'}
+            </button>
+          </div>
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/output_system/frontend/src/app/author/books/page.tsx
+++ b/output_system/frontend/src/app/author/books/page.tsx
@@ -1,16 +1,49 @@
 /**
  * @file author/books/page.tsx
- * @description 著者向け書籍一覧（プレースホルダー）
+ * @description 著者向け書籍一覧画面
  *
- * ログイン後の著者向け書籍管理画面。
- * 後続のPBIで本実装を行う。
+ * 著者が登録した書籍の一覧を表示する画面。
+ * 書籍の登録・編集・削除操作へのエントリポイント。
+ *
+ * 機能:
+ * - 書籍一覧の表示（タイトル・形式・ステータス・登録日）
+ * - 新規書籍登録ページへのリンク
+ * - ログアウト
  */
 
 'use client';
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { getToken, apiGetMe, apiLogout, AuthUser } from '../../../lib/api';
+import { getToken, apiGetMe, apiLogout, apiGetBooks, apiDeleteBook, AuthUser, Book, ApiError } from '../../../lib/api';
+
+/**
+ * ファイルサイズを人間が読みやすい形式に変換する
+ *
+ * @param bytes - バイト数（null可）
+ * @returns フォーマットされたファイルサイズ文字列
+ */
+function formatFileSize(bytes: number | null): string {
+  if (bytes === null) return '–';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * 書籍ステータスの表示ラベルを返す
+ *
+ * @param status - 書籍ステータス
+ * @returns 表示用ラベル
+ */
+function getStatusLabel(status: Book['status']): { label: string; color: string; bg: string } {
+  switch (status) {
+    case 'draft': return { label: '下書き', color: '#92400e', bg: '#fef3c7' };
+    case 'published': return { label: '公開中', color: '#065f46', bg: '#d1fae5' };
+    case 'archived': return { label: 'アーカイブ', color: '#374151', bg: '#f3f4f6' };
+    default: return { label: status, color: '#374151', bg: '#f3f4f6' };
+  }
+}
 
 /**
  * 著者向け書籍一覧コンポーネント
@@ -20,11 +53,14 @@ import { getToken, apiGetMe, apiLogout, AuthUser } from '../../../lib/api';
 export default function AuthorBooks() {
   const router = useRouter();
   const [user, setUser] = useState<AuthUser | null>(null);
+  const [books, setBooks] = useState<Book[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
-  // マウント時に認証状態を確認する
+  // マウント時に認証状態と書籍一覧を取得する
   useEffect(() => {
-    async function checkAuth() {
+    async function loadData() {
       const token = getToken();
       if (!token) {
         router.push('/admin/login');
@@ -32,26 +68,63 @@ export default function AuthorBooks() {
       }
 
       try {
-        const result = await apiGetMe();
-        if (result.user.role !== 'author') {
+        const [meResult, booksResult] = await Promise.all([
+          apiGetMe(),
+          apiGetBooks(),
+        ]);
+
+        if (meResult.user.role !== 'author') {
           // authorロール以外はアクセス不可
           router.push('/admin/login');
           return;
         }
-        setUser(result.user);
-      } catch {
-        router.push('/admin/login');
+
+        setUser(meResult.user);
+        setBooks(booksResult.books);
+      } catch (err) {
+        const apiError = err as ApiError;
+        if (apiError.statusCode === 401) {
+          router.push('/admin/login');
+        } else {
+          setError('データの読み込みに失敗しました');
+        }
       } finally {
         setIsLoading(false);
       }
     }
 
-    checkAuth();
+    loadData();
   }, [router]);
 
+  /**
+   * ログアウト処理
+   */
   async function handleLogout() {
     await apiLogout();
     router.push('/admin/login');
+  }
+
+  /**
+   * 書籍削除処理
+   * 確認ダイアログを表示してから削除を実行する
+   *
+   * @param book - 削除する書籍
+   */
+  async function handleDeleteBook(book: Book) {
+    if (!window.confirm(`「${book.title}」を削除しますか？この操作は取り消せません。`)) {
+      return;
+    }
+
+    setDeletingId(book.id);
+    try {
+      await apiDeleteBook(book.id);
+      setBooks((prev) => prev.filter((b) => b.id !== book.id));
+    } catch (err) {
+      const apiError = err as ApiError;
+      alert(`削除に失敗しました: ${apiError.message}`);
+    } finally {
+      setDeletingId(null);
+    }
   }
 
   if (isLoading) {
@@ -63,11 +136,21 @@ export default function AuthorBooks() {
   }
 
   return (
-    <div style={{ padding: '2rem', maxWidth: '1200px', margin: '0 auto' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem' }}>
-        <h1 style={{ fontSize: '1.8rem', color: '#111' }}>書籍一覧</h1>
+    <div style={{ minHeight: '100vh', backgroundColor: '#f9fafb' }}>
+      {/* ヘッダー */}
+      <header style={{
+        backgroundColor: '#fff',
+        borderBottom: '1px solid #e5e7eb',
+        padding: '1rem 2rem',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}>
+        <h1 style={{ fontSize: '1.25rem', fontWeight: '600', color: '#111827' }}>書籍管理</h1>
         <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-          <span style={{ color: '#555' }}>{user?.name}（著者）</span>
+          <span style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+            {user?.name}（著者）
+          </span>
           <button
             onClick={handleLogout}
             style={{
@@ -77,13 +160,183 @@ export default function AuthorBooks() {
               background: 'none',
               color: '#dc2626',
               cursor: 'pointer',
+              fontSize: '0.875rem',
             }}
           >
             ログアウト
           </button>
         </div>
-      </div>
-      <p style={{ color: '#666' }}>書籍管理機能は後続のPBIで実装予定です。</p>
+      </header>
+
+      {/* メインコンテンツ */}
+      <main style={{ maxWidth: '1200px', margin: '0 auto', padding: '2rem' }}>
+        {/* アクションバー */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
+          <p style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+            {books.length}件の書籍
+          </p>
+          <button
+            onClick={() => router.push('/author/books/new')}
+            style={{
+              padding: '0.625rem 1.25rem',
+              backgroundColor: '#2563eb',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '0.875rem',
+              fontWeight: '500',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}
+          >
+            + 書籍を登録する
+          </button>
+        </div>
+
+        {/* エラー表示 */}
+        {error && (
+          <div style={{
+            backgroundColor: '#fef2f2',
+            border: '1px solid #fecaca',
+            borderRadius: '6px',
+            padding: '0.75rem 1rem',
+            marginBottom: '1rem',
+            color: '#991b1b',
+            fontSize: '0.875rem',
+          }}>
+            {error}
+          </div>
+        )}
+
+        {/* 書籍一覧 */}
+        {books.length === 0 ? (
+          /* 書籍がない場合の空状態 */
+          <div style={{
+            backgroundColor: '#fff',
+            borderRadius: '12px',
+            padding: '4rem 2rem',
+            textAlign: 'center',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+          }}>
+            <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>📚</div>
+            <p style={{ fontSize: '1rem', color: '#374151', marginBottom: '0.5rem', fontWeight: '500' }}>
+              まだ書籍が登録されていません
+            </p>
+            <p style={{ fontSize: '0.875rem', color: '#6b7280', marginBottom: '1.5rem' }}>
+              PDFまたはEPUBファイルをアップロードして書籍を登録しましょう
+            </p>
+            <button
+              onClick={() => router.push('/author/books/new')}
+              style={{
+                padding: '0.625rem 1.5rem',
+                backgroundColor: '#2563eb',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '8px',
+                cursor: 'pointer',
+                fontSize: '0.875rem',
+                fontWeight: '500',
+              }}
+            >
+              最初の書籍を登録する
+            </button>
+          </div>
+        ) : (
+          /* 書籍カードリスト */
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            {books.map((book) => {
+              const statusInfo = getStatusLabel(book.status);
+              return (
+                <div
+                  key={book.id}
+                  style={{
+                    backgroundColor: '#fff',
+                    borderRadius: '12px',
+                    padding: '1.25rem 1.5rem',
+                    boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: '1rem',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flex: 1, minWidth: 0 }}>
+                    {/* ファイル形式アイコン */}
+                    <div style={{
+                      width: '40px',
+                      height: '40px',
+                      borderRadius: '8px',
+                      backgroundColor: book.format === 'pdf' ? '#fef3c7' : '#dbeafe',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: '1.25rem',
+                      flexShrink: 0,
+                    }}>
+                      {book.format === 'pdf' ? '📕' : '📗'}
+                    </div>
+
+                    {/* 書籍情報 */}
+                    <div style={{ minWidth: 0 }}>
+                      <p style={{
+                        fontSize: '0.9375rem',
+                        fontWeight: '500',
+                        color: '#111827',
+                        marginBottom: '0.25rem',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}>
+                        {book.title}
+                      </p>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+                        <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>
+                          {book.format.toUpperCase()} • {formatFileSize(book.fileSize)}
+                        </span>
+                        <span style={{
+                          fontSize: '0.75rem',
+                          fontWeight: '500',
+                          color: statusInfo.color,
+                          backgroundColor: statusInfo.bg,
+                          padding: '0.125rem 0.5rem',
+                          borderRadius: '4px',
+                        }}>
+                          {statusInfo.label}
+                        </span>
+                        <span style={{ fontSize: '0.75rem', color: '#9ca3af' }}>
+                          {new Date(book.createdAt).toLocaleDateString('ja-JP')}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* アクションボタン */}
+                  <div style={{ display: 'flex', gap: '0.5rem', flexShrink: 0 }}>
+                    <button
+                      onClick={() => handleDeleteBook(book)}
+                      disabled={deletingId === book.id}
+                      style={{
+                        padding: '0.375rem 0.875rem',
+                        border: '1px solid #fecaca',
+                        borderRadius: '6px',
+                        backgroundColor: deletingId === book.id ? '#f3f4f6' : '#fff',
+                        color: '#ef4444',
+                        cursor: deletingId === book.id ? 'not-allowed' : 'pointer',
+                        fontSize: '0.8125rem',
+                        opacity: deletingId === book.id ? 0.6 : 1,
+                      }}
+                    >
+                      {deletingId === book.id ? '削除中...' : '削除'}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </main>
     </div>
   );
 }

--- a/output_system/frontend/src/lib/api.ts
+++ b/output_system/frontend/src/lib/api.ts
@@ -219,3 +219,129 @@ export function saveOAuthToken(backendToken: string): void {
 export async function apiGetMe(): Promise<{ user: AuthUser }> {
   return apiRequest('/auth/me');
 }
+
+// ===== 書籍API =====
+
+/**
+ * 書籍エンティティ型定義
+ * バックエンドの Book 型に対応する
+ */
+export interface Book {
+  id: string;
+  authorId: string;
+  title: string;
+  description: string | null;
+  format: 'pdf' | 'epub';
+  fileKey: string | null;
+  coverImageKey: string | null;
+  fileSize: number | null;
+  pageCount: number | null;
+  status: 'draft' | 'published' | 'archived';
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * multipart/form-data でファイルをアップロードする汎用APIリクエスト関数
+ * `apiRequest()` はJSON送信専用のため、ファイルアップロード時はこちらを使用する
+ *
+ * @param path - APIパス（例: '/books'）
+ * @param formData - アップロードするFormDataオブジェクト
+ * @param method - HTTPメソッド（デフォルト: POST）
+ * @returns レスポンスデータ
+ * @throws {ApiError} APIエラーが発生した場合
+ */
+export async function apiUploadRequest<T>(
+  path: string,
+  formData: FormData,
+  method: 'POST' | 'PUT' = 'POST'
+): Promise<T> {
+  const token = getToken();
+  const headers: Record<string, string> = {};
+
+  // JWTトークンを付与（Content-Typeはmultipart/form-dataにするためヘッダーに含めない）
+  // fetch APIがFormData渡し時に自動的にContent-Typeを設定するため、手動設定不要
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers,
+    body: formData,
+  });
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    data = null;
+  }
+
+  if (!response.ok) {
+    const errorData = data as Partial<ApiError>;
+    throw {
+      error: errorData?.error || 'UNKNOWN_ERROR',
+      message: errorData?.message || `HTTPエラー: ${response.status}`,
+      statusCode: response.status,
+    } as ApiError;
+  }
+
+  return data as T;
+}
+
+/**
+ * 書籍一覧を取得する
+ *
+ * @returns 書籍の配列と件数
+ * @throws {ApiError} APIエラーが発生した場合
+ */
+export async function apiGetBooks(): Promise<{ books: Book[]; count: number }> {
+  return apiRequest('/books');
+}
+
+/**
+ * 書籍を新規登録する（ファイルアップロード）
+ *
+ * @param formData - 書籍データ（bookFile, title, description, coverImage, metadata）
+ * @param onProgress - アップロード進捗コールバック（0-100の数値）
+ * @returns 作成した書籍オブジェクト
+ * @throws {ApiError} APIエラーが発生した場合
+ */
+export async function apiCreateBook(formData: FormData): Promise<{ book: Book }> {
+  return apiUploadRequest<{ book: Book }>('/books', formData, 'POST');
+}
+
+/**
+ * 書籍詳細を取得する
+ *
+ * @param bookId - 書籍ID
+ * @returns 書籍オブジェクト
+ * @throws {ApiError} APIエラーが発生した場合
+ */
+export async function apiGetBook(bookId: string): Promise<{ book: Book }> {
+  return apiRequest(`/books/${bookId}`);
+}
+
+/**
+ * 書籍情報を更新する
+ *
+ * @param bookId - 書籍ID
+ * @param formData - 更新データ（bookFile, title, description, coverImage）
+ * @returns 更新後の書籍オブジェクト
+ * @throws {ApiError} APIエラーが発生した場合
+ */
+export async function apiUpdateBook(bookId: string, formData: FormData): Promise<{ book: Book }> {
+  return apiUploadRequest<{ book: Book }>(`/books/${bookId}`, formData, 'PUT');
+}
+
+/**
+ * 書籍を削除する
+ *
+ * @param bookId - 書籍ID
+ * @throws {ApiError} APIエラーが発生した場合
+ */
+export async function apiDeleteBook(bookId: string): Promise<void> {
+  return apiRequest(`/books/${bookId}`, { method: 'DELETE' });
+}


### PR DESCRIPTION
## Summary

著者がPDF/EPUBファイルをアップロードしてメタデータとともに書籍を登録できる機能を実装しました。ファイルはS3互換ストレージ（MinIO）に保存されます。

### 実装内容

**対象PBI**: #9 PBI 2.1: 著者が電子書籍をアップロードし登録できる
- #29 Task 2.1.1: 書籍CRUD APIを実装する ✅
- #30 Task 2.1.2: 書籍登録画面を作成する ✅

### 変更ファイル

**バックエンド**
- `output_system/backend/src/models/book.model.ts`: BookModel（CRUD操作）
- `output_system/backend/src/services/books.service.ts`: BooksService（ファイルアップロード・認可チェック）
- `output_system/backend/src/controllers/books.controller.ts`: 書籍CRUD APIコントローラー
- `output_system/backend/src/routes/books.routes.ts`: multer 50MB制限・fileFilter・ルート定義
- `output_system/backend/src/routes/index.ts`: /booksルーターをマウント
- `output_system/backend/src/services/storage.service.ts`: SSEデフォルト値を修正
- `output_system/backend/test/services/books.service.test.ts`: 18件のユニットテスト追加
- `output_system/backend/package.json`: multer@2.1.1追加

**フロントエンド**
- `output_system/frontend/src/app/author/books/new/page.tsx`: 書籍登録画面（ドラッグ&ドロップ・進捗バー）
- `output_system/frontend/src/app/author/books/page.tsx`: 書籍一覧画面を実装
- `output_system/frontend/src/lib/api.ts`: 書籍CRUD API関数追加（apiUploadRequest含む）
- `output_system/frontend/next.config.js`: beforeFilesで認証APIプロキシを修正

## Test Plan

- [x] PDFファイルをアップロードして書籍登録できる
- [x] EPUBファイルをアップロードして書籍登録できる
- [x] 50MB以下のファイルが正常にアップロードされる
- [x] 50MBを超えるファイルは413エラーになる
- [x] ファイルがS3に保存される（本番環境ではAES-256暗号化: S3_ENABLE_SSE=true）
- [x] タイトル・説明・表紙画像を登録できる
- [x] 書籍登録画面にドラッグ&ドロップ対応のアップロードUIがある
- [x] GET /api/books で著者自身の書籍一覧が返る
- [x] GET /api/books/:id で書籍詳細が返る
- [x] PUT /api/books/:id で書籍情報を更新できる
- [x] DELETE /api/books/:id で書籍とS3ファイルが削除される
- [x] 他の著者の書籍は操作できない（403が返る）
- [x] ユニットテスト62件すべてpass

## Screenshots

| 画面名 | スクリーンショット |
|--------|-------------------|
| 書籍一覧画面 | ![書籍一覧](https://github.com/okegawaatclink/gaido-signia/raw/f2db7cd01a1879ca4726d08afd016200215c54cb/ai_generated/screenshots/task-30_book-list.png) |
| 書籍登録画面 | ![書籍登録フォーム](https://github.com/okegawaatclink/gaido-signia/raw/f2db7cd01a1879ca4726d08afd016200215c54cb/ai_generated/screenshots/task-30_new-book-form.png) |
| 登録後の書籍一覧 | ![登録後一覧](https://github.com/okegawaatclink/gaido-signia/raw/f2db7cd01a1879ca4726d08afd016200215c54cb/ai_generated/screenshots/task-30_book-list-after-create.png) |

## Related Issues

- Closes #9

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)