### PR TITLE
[PBI 5.1: 著者アカウント管理] 実装完了

### DIFF
--- a/ai_generated/HANDOVER.md
+++ b/ai_generated/HANDOVER.md
@@ -139,6 +139,12 @@ docker compose up -d
 - **Jest ClassのinstanceofがESModuleモックで失敗**: `jest.mock()`でクラスをモックするとprototypeチェーンが切れて`rejects.toThrow(SomeError)`がコンストラクタ比較で失敗する。`rejects.toThrow('エラーメッセージ文字列')`による文字列マッチに変更する
 - **validationResult のTypeScript型キャスト**: express-validatorの`validationResult`はジェネリック型`ResultFactory<E>`を返すため`as jest.Mock`への直接キャストがコンパイルエラーになる。`as unknown as jest.Mock`の二段階キャストで回避
 
+- **著者管理: ConflictError (409) 追加**: メールアドレス重複時に409を返すため `utils/errors.ts` に `ConflictError` を追加。`AppError` の既存パターンに従うこと
+- **著者無効化は論理削除**: `DELETE /api/admin/authors/:id` は is_active=false に変更するのみ（物理削除なし）。無効化された著者は `auth.service.ts` の is_active チェックでログイン拒否される
+- **pdfjs-dist v5 RenderParameters**: v5ではRenderParametersに `canvas` フィールドが必須。`canvasContext` だけでは型エラーになる。`{ canvas, canvasContext: ctx, viewport }` で渡す
+- **pdfjs-dist v5 WorkerSrc**: v5ではGlobalWorkerOptions.workerSrcはCDN URLを設定する（node_modules内のworkerはwebpackで直接参照できないため）
+- **epub.js 動的インポート**: epub.jsはSSR非対応のため `import('epubjs').default` で動的インポートする。Book/Rendition型はoverloadのせいで `as unknown as EpubBook` でキャストが必要
+- **ビューアーページのNext.js routing**: ファン向けビューアーは `(fan)/reader/[bookId]` の Route Groupに配置。URLは `/reader/[bookId]` になる
 - **ランディングページSSG**: ランディングページ（`app/page.tsx`）はServer Componentとして実装しSSGで生成。Client Componentをimportする場合でも、イベントハンドラーを持つコンポーネントは `'use client'` を付けること
 - **FooterのhoverはClient Component必須**: `onMouseEnter/onMouseLeave` イベントハンドラーはClient Componentでしか使えない。Server Componentのランディングページに使うFooterは `'use client'` が必要
 - **FanBookCardのNext.js Image unoptimized**: MinIOの署名付きURLはドメインが動的に変わるため `unoptimized` プロパティを使用。`next.config.js` の `remotePatterns` に加えて `unoptimized` を設定することで外部URLを直接表示できる
@@ -169,3 +175,5 @@ docker compose up -d
 - PBI #12: 著者が作成済みサインを一覧・編集・削除できる (SignCardコンポーネント・サイン一覧/詳細・編集画面・JWT認証付き画像fetch・再作成モード・削除確認ダイアログ)
 - PBI #13: 著者がサインを電子書籍に合成できる (pdf-lib PDF合成・JSZip EPUB合成・ComposeService・合成API・サイン合成画面・SignComposerプレビュー)
 - PBI #14: ファンが本棚でサイン入り書籍一覧を確認できる (FanService・本棚API・ランディングページ・本棚画面・Header/Footer/FanBookCardコンポーネント)
+- PBI #15: ファンがDRM保護付きで電子書籍を閲覧できる (pdfjs-dist v5 PDFビューアー・epub.js EPUBビューアー・署名付きURL15分・右クリック禁止・印刷制限・ビューアー画面)
+- PBI #16: 管理者が著者アカウントを作成・管理できる (adminService・著者CRUD API・著者管理画面・Sidebar・ConflictError追加)

--- a/output_system/backend/src/controllers/admin.controller.ts
+++ b/output_system/backend/src/controllers/admin.controller.ts
@@ -1,0 +1,233 @@
+/**
+ * @file admin.controller.ts
+ * @description 管理者向けコントローラー
+ *
+ * 著者アカウント管理の HTTP リクエスト処理を担当する。
+ * リクエストバリデーション、サービス呼び出し、レスポンス整形を行う。
+ *
+ * エンドポイント:
+ * - GET    /api/admin/authors       : 著者一覧取得
+ * - POST   /api/admin/authors       : 著者アカウント作成
+ * - GET    /api/admin/authors/:id   : 著者詳細取得（登録書籍一覧含む）
+ * - PUT    /api/admin/authors/:id   : 著者情報更新
+ * - DELETE /api/admin/authors/:id   : 著者アカウント無効化
+ *
+ * 認証・認可:
+ * - 全エンドポイントに JWT 認証が必要（authenticate）
+ * - admin ロールのみアクセス可能（adminOnly）
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { validationResult } from 'express-validator';
+import { adminService } from '../services/admin.service';
+import { ValidationError } from '../utils/errors';
+import { logger } from '../utils/logger';
+
+/**
+ * GET /api/admin/authors
+ * 著者一覧を取得する
+ *
+ * レスポンス (200):
+ * - authors: 著者情報の配列（パスワードなし）
+ * - count: 著者数
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function getAuthors(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    logger.info('GET /api/admin/authors called', { adminId: req.user?.userId });
+
+    const authors = await adminService.getAuthors();
+
+    res.status(200).json({
+      authors,
+      count: authors.length,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * POST /api/admin/authors
+ * 著者アカウントを新規作成する
+ *
+ * リクエスト (application/json):
+ * - email: メールアドレス（必須、有効なメール形式）
+ * - name: 表示名（必須、1〜100 文字）
+ * - password: 初期パスワード（必須、8 文字以上）
+ *
+ * レスポンス (201):
+ * - author: 作成した著者情報（パスワードなし）
+ *
+ * エラー:
+ * - 400: バリデーションエラー（メール形式不正、パスワード短すぎ等）
+ * - 409: メールアドレスが既に使用されている
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function createAuthor(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const { email, name, password } = req.body;
+    logger.info('POST /api/admin/authors called', { adminId: req.user?.userId, email, name });
+
+    const author = await adminService.createAuthor({ email, name, password });
+
+    res.status(201).json({ author });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * GET /api/admin/authors/:id
+ * 著者詳細を取得する（登録書籍一覧含む）
+ *
+ * レスポンス (200):
+ * - author: 著者詳細情報（登録書籍一覧含む）
+ *
+ * エラー:
+ * - 400: 著者 ID が不正な形式
+ * - 404: 著者が見つからない
+ *
+ * @param req - Express リクエストオブジェクト（req.params.id に著者 ID）
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function getAuthor(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const { id } = req.params;
+    logger.info('GET /api/admin/authors/:id called', { adminId: req.user?.userId, authorId: id });
+
+    const author = await adminService.getAuthorById(id);
+
+    res.status(200).json({ author });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * PUT /api/admin/authors/:id
+ * 著者情報を更新する
+ *
+ * リクエスト (application/json):
+ * - name: 表示名（オプション）
+ * - email: メールアドレス（オプション）
+ * - isActive: アカウント有効フラグ（オプション）
+ *
+ * レスポンス (200):
+ * - author: 更新後の著者情報
+ *
+ * エラー:
+ * - 400: バリデーションエラー
+ * - 404: 著者が見つからない
+ * - 409: 変更後のメールアドレスが既に使用されている
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function updateAuthor(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const { id } = req.params;
+    const { name, email, isActive } = req.body;
+    logger.info('PUT /api/admin/authors/:id called', { adminId: req.user?.userId, authorId: id });
+
+    const author = await adminService.updateAuthor(id, { name, email, isActive });
+
+    res.status(200).json({ author });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * DELETE /api/admin/authors/:id
+ * 著者アカウントを無効化する（論理削除）
+ *
+ * is_active フラグを false に変更する（物理削除は行わない）。
+ * 無効化された著者はログインできなくなる。
+ *
+ * レスポンス (200):
+ * - author: 無効化後の著者情報
+ * - message: 完了メッセージ
+ *
+ * エラー:
+ * - 400: 著者 ID が不正な形式
+ * - 404: 著者が見つからない
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function deactivateAuthor(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const { id } = req.params;
+    logger.info('DELETE /api/admin/authors/:id called', {
+      adminId: req.user?.userId,
+      authorId: id,
+    });
+
+    const author = await adminService.deactivateAuthor(id);
+
+    res.status(200).json({
+      author,
+      message: '著者アカウントを無効化しました',
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/output_system/backend/src/routes/admin.routes.ts
+++ b/output_system/backend/src/routes/admin.routes.ts
@@ -1,0 +1,146 @@
+/**
+ * @file admin.routes.ts
+ * @description 管理者向け API ルーター
+ *
+ * 著者アカウント管理エンドポイントを定義する。
+ *
+ * エンドポイント:
+ * - GET    /api/admin/authors       : 著者一覧取得
+ * - POST   /api/admin/authors       : 著者アカウント作成
+ * - GET    /api/admin/authors/:id   : 著者詳細取得（登録書籍一覧含む）
+ * - PUT    /api/admin/authors/:id   : 著者情報更新
+ * - DELETE /api/admin/authors/:id   : 著者アカウント無効化（論理削除）
+ *
+ * 認証・認可:
+ * - 全エンドポイントに JWT 認証が必要（authenticate）
+ * - admin ロールのみアクセス可能（adminOnly）
+ * - admin 以外のロール（author, fan）には 403 が返る
+ */
+
+import { Router } from 'express';
+import { body, param } from 'express-validator';
+import { authenticate } from '../middleware/auth.middleware';
+import { adminOnly } from '../middleware/rbac.middleware';
+import {
+  getAuthors,
+  createAuthor,
+  getAuthor,
+  updateAuthor,
+  deactivateAuthor,
+} from '../controllers/admin.controller';
+
+const router = Router();
+
+// ======= 著者管理ルート =======
+
+/**
+ * GET /api/admin/authors
+ * 著者一覧取得
+ * admin ロールのみアクセス可能
+ */
+router.get('/authors', authenticate, adminOnly, getAuthors);
+
+/**
+ * POST /api/admin/authors
+ * 著者アカウント新規作成
+ *
+ * リクエストボディのバリデーション:
+ * - email: 有効なメールアドレス形式（必須）
+ * - name: 1〜100 文字（必須）
+ * - password: 8 文字以上（必須）
+ */
+router.post(
+  '/authors',
+  authenticate,
+  adminOnly,
+  [
+    // メールアドレスは必須かつ有効な形式
+    body('email')
+      .notEmpty()
+      .withMessage('メールアドレスは必須です')
+      .isEmail()
+      .withMessage('有効なメールアドレスを入力してください')
+      .normalizeEmail(),
+    // 表示名は必須かつ 1〜100 文字
+    body('name')
+      .notEmpty()
+      .withMessage('名前は必須です')
+      .isLength({ min: 1, max: 100 })
+      .withMessage('名前は 1〜100 文字で入力してください')
+      .trim(),
+    // パスワードは必須かつ 8 文字以上
+    body('password')
+      .notEmpty()
+      .withMessage('パスワードは必須です')
+      .isLength({ min: 8 })
+      .withMessage('パスワードは 8 文字以上で入力してください'),
+  ],
+  createAuthor
+);
+
+/**
+ * GET /api/admin/authors/:id
+ * 著者詳細取得（登録書籍一覧含む）
+ *
+ * パラメータバリデーション:
+ * - id: UUID 形式
+ */
+router.get(
+  '/authors/:id',
+  authenticate,
+  adminOnly,
+  [param('id').isUUID().withMessage('著者 ID が不正です')],
+  getAuthor
+);
+
+/**
+ * PUT /api/admin/authors/:id
+ * 著者情報更新
+ *
+ * リクエストボディのバリデーション:
+ * - email: 有効なメールアドレス形式（オプション）
+ * - name: 1〜100 文字（オプション）
+ * - isActive: boolean（オプション）
+ */
+router.put(
+  '/authors/:id',
+  authenticate,
+  adminOnly,
+  [
+    param('id').isUUID().withMessage('著者 ID が不正です'),
+    // email はオプションだが、指定する場合は有効なメール形式
+    body('email')
+      .optional()
+      .isEmail()
+      .withMessage('有効なメールアドレスを入力してください')
+      .normalizeEmail(),
+    // name はオプションだが、指定する場合は空でない 1〜100 文字
+    body('name')
+      .optional()
+      .notEmpty()
+      .withMessage('名前は空にできません')
+      .isLength({ max: 100 })
+      .withMessage('名前は 100 文字以内で入力してください')
+      .trim(),
+    // isActive はオプションの boolean
+    body('isActive').optional().isBoolean().withMessage('isActive は true または false で指定してください'),
+  ],
+  updateAuthor
+);
+
+/**
+ * DELETE /api/admin/authors/:id
+ * 著者アカウント無効化（論理削除）
+ *
+ * パラメータバリデーション:
+ * - id: UUID 形式
+ */
+router.delete(
+  '/authors/:id',
+  authenticate,
+  adminOnly,
+  [param('id').isUUID().withMessage('著者 ID が不正です')],
+  deactivateAuthor
+);
+
+export default router;

--- a/output_system/backend/src/routes/index.ts
+++ b/output_system/backend/src/routes/index.ts
@@ -12,6 +12,7 @@ import booksRouter from './books.routes';
 import signsRouter from './signs.routes';
 import composeRouter from './compose.routes';
 import fanRouter from './fan.routes';
+import adminRouter from './admin.routes';
 
 /**
  * メインAPIルーター
@@ -50,8 +51,10 @@ router.use('/compose', composeRouter);
 // ファン向けAPIルーターをマウント
 router.use('/fan', fanRouter);
 
+// 管理者向けAPIルーターをマウント（admin ロールのみアクセス可能）
+router.use('/admin', adminRouter);
+
 // TODO: 以下の各ルーターは後続のTaskで実装する
-// router.use('/admin', adminRouter);
 // router.use('/external', externalRouter);
 
 export default router;

--- a/output_system/backend/src/services/admin.service.ts
+++ b/output_system/backend/src/services/admin.service.ts
@@ -1,0 +1,378 @@
+/**
+ * @file admin.service.ts
+ * @description 管理者向けビジネスロジックサービス
+ *
+ * 著者アカウントの CRUD 操作に関するビジネスロジックを提供する。
+ * - 著者アカウント作成（初期パスワードのハッシュ化・author ロール設定）
+ * - 著者一覧取得
+ * - 著者詳細取得（登録書籍一覧含む）
+ * - 著者情報編集（名前・メール・有効/無効フラグ）
+ * - 著者アカウント無効化（is_active フラグ変更: 論理削除）
+ *
+ * セキュリティ:
+ * - このサービスは admin ロールのユーザーのみ呼び出し可能
+ * - 著者作成時のパスワードは bcrypt でハッシュ化する
+ * - 無効化された著者はログインできない（auth.service.ts の is_active チェックによる）
+ */
+
+import { db } from '../config/database';
+import { hashPassword } from '../utils/crypto';
+import { ConflictError, NotFoundError } from '../utils/errors';
+import { logger } from '../utils/logger';
+
+// ===== 型定義 =====
+
+/**
+ * 著者情報型（API レスポンス用、パスワードハッシュを含まない）
+ */
+export interface AuthorInfo {
+  /** ユーザー ID（UUID） */
+  id: string;
+  /** メールアドレス */
+  email: string;
+  /** 表示名 */
+  name: string;
+  /** ロール（常に 'author'） */
+  role: 'author';
+  /** アカウント有効フラグ */
+  isActive: boolean;
+  /** 作成日時 */
+  createdAt: Date;
+  /** 更新日時 */
+  updatedAt: Date;
+}
+
+/**
+ * 著者詳細型（登録書籍一覧を含む）
+ */
+export interface AuthorDetail extends AuthorInfo {
+  /** 著者が登録した書籍の一覧 */
+  books: AuthorBook[];
+}
+
+/**
+ * 著者の書籍情報型（著者詳細画面用）
+ */
+export interface AuthorBook {
+  /** 書籍 ID（UUID） */
+  id: string;
+  /** 書籍タイトル */
+  title: string;
+  /** 書籍のステータス */
+  status: 'draft' | 'published' | 'archived';
+  /** ファイル形式（pdf/epub） */
+  format: string | null;
+  /** 作成日時 */
+  createdAt: Date;
+}
+
+/**
+ * 著者アカウント作成パラメータ
+ */
+export interface CreateAuthorParams {
+  /** メールアドレス（必須、一意） */
+  email: string;
+  /** 表示名（必須） */
+  name: string;
+  /** 初期パスワード（必須、ハッシュ化して保存） */
+  password: string;
+}
+
+/**
+ * 著者情報更新パラメータ
+ */
+export interface UpdateAuthorParams {
+  /** 表示名（オプション） */
+  name?: string;
+  /** メールアドレス（オプション、重複チェックあり） */
+  email?: string;
+  /** アカウント有効フラグ（オプション） */
+  isActive?: boolean;
+}
+
+// ===== ヘルパー関数 =====
+
+/**
+ * DB 行データを AuthorInfo 型にマッピングする
+ * snake_case（DB 列名）から camelCase（TypeScript）への変換を行う
+ *
+ * @param row - DB から取得した行データ
+ * @returns AuthorInfo 型のオブジェクト
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mapRowToAuthorInfo(row: Record<string, any>): AuthorInfo {
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    role: 'author',
+    isActive: row.is_active,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ===== サービス関数 =====
+
+/**
+ * 著者アカウントを新規作成する
+ *
+ * - メールアドレスの重複チェック
+ * - パスワードを bcrypt でハッシュ化
+ * - author ロールで users テーブルに INSERT
+ *
+ * @param params - 著者作成パラメータ
+ * @returns 作成した著者情報（パスワードハッシュなし）
+ * @throws {ConflictError} 指定メールアドレスが既に使用されている場合
+ *
+ * @example
+ * const author = await createAuthor({
+ *   email: 'newauthor@example.com',
+ *   name: '新規著者',
+ *   password: 'SecurePassword123',
+ * });
+ */
+export async function createAuthor(params: CreateAuthorParams): Promise<AuthorInfo> {
+  const { email, name, password } = params;
+
+  // メールアドレスの重複チェック（DB レベルでも UNIQUE 制約があるが、先にチェックして分かりやすいエラーを返す）
+  const existingUser = await db.query<{ count: string }>(
+    'SELECT COUNT(*) as count FROM users WHERE email = $1',
+    [email]
+  );
+  if (parseInt(existingUser.rows[0].count, 10) > 0) {
+    logger.warn('Author creation failed: email already exists', { email });
+    throw new ConflictError('このメールアドレスは既に使用されています');
+  }
+
+  // パスワードをハッシュ化（bcrypt salt rounds 12）
+  const passwordHash = await hashPassword(password);
+
+  // 著者アカウントを DB に挿入
+  const result = await db.query<Record<string, unknown>>(
+    `INSERT INTO users (email, name, role, password_hash, is_active)
+     VALUES ($1, $2, 'author', $3, true)
+     RETURNING id, email, name, role, is_active, created_at, updated_at`,
+    [email, name, passwordHash]
+  );
+
+  const author = mapRowToAuthorInfo(result.rows[0]);
+  logger.info('Author account created', { authorId: author.id, email: author.email });
+
+  return author;
+}
+
+/**
+ * 著者一覧を取得する
+ *
+ * role = 'author' のユーザーを全件取得する。
+ * パスワードハッシュは含まない。
+ *
+ * @returns 著者情報の配列（作成日時降順）
+ *
+ * @example
+ * const authors = await getAuthors();
+ */
+export async function getAuthors(): Promise<AuthorInfo[]> {
+  const result = await db.query<Record<string, unknown>>(
+    `SELECT id, email, name, is_active, created_at, updated_at
+     FROM users
+     WHERE role = 'author'
+     ORDER BY created_at DESC`
+  );
+
+  return result.rows.map(mapRowToAuthorInfo);
+}
+
+/**
+ * 著者詳細を取得する（登録書籍一覧含む）
+ *
+ * 指定 ID のユーザーが author ロールの場合、著者情報と登録書籍の一覧を返す。
+ *
+ * @param authorId - 著者の ID（UUID）
+ * @returns 著者詳細情報（登録書籍一覧含む）
+ * @throws {NotFoundError} 指定 ID の著者が存在しない場合
+ *
+ * @example
+ * const detail = await getAuthorById('author-uuid-here');
+ */
+export async function getAuthorById(authorId: string): Promise<AuthorDetail> {
+  // 著者情報を取得
+  const userResult = await db.query<Record<string, unknown>>(
+    `SELECT id, email, name, is_active, created_at, updated_at
+     FROM users
+     WHERE id = $1 AND role = 'author'`,
+    [authorId]
+  );
+
+  if (userResult.rows.length === 0) {
+    logger.warn('Author not found', { authorId });
+    throw new NotFoundError('著者が見つかりません');
+  }
+
+  const author = mapRowToAuthorInfo(userResult.rows[0]);
+
+  // 登録書籍一覧を取得（読み取り専用、作成日時降順）
+  const booksResult = await db.query<Record<string, unknown>>(
+    `SELECT id, title, status, format, created_at
+     FROM books
+     WHERE author_id = $1
+     ORDER BY created_at DESC`,
+    [authorId]
+  );
+
+  const books: AuthorBook[] = booksResult.rows.map((row) => ({
+    id: row.id as string,
+    title: row.title as string,
+    status: row.status as 'draft' | 'published' | 'archived',
+    format: row.format as string | null,
+    createdAt: row.created_at as Date,
+  }));
+
+  return { ...author, books };
+}
+
+/**
+ * 著者情報を更新する
+ *
+ * 名前・メールアドレス・有効/無効フラグを更新可能。
+ * メールアドレスを変更する場合は重複チェックを行う。
+ *
+ * @param authorId - 更新対象の著者 ID（UUID）
+ * @param params - 更新パラメータ（未指定のフィールドは変更しない）
+ * @returns 更新後の著者情報
+ * @throws {NotFoundError} 指定 ID の著者が存在しない場合
+ * @throws {ConflictError} 変更後のメールアドレスが既に使用されている場合
+ *
+ * @example
+ * const updated = await updateAuthor('author-uuid', { name: '新しい名前' });
+ */
+export async function updateAuthor(
+  authorId: string,
+  params: UpdateAuthorParams
+): Promise<AuthorInfo> {
+  // 著者の存在確認
+  const existingResult = await db.query<Record<string, unknown>>(
+    `SELECT id, email, name, is_active, created_at, updated_at
+     FROM users
+     WHERE id = $1 AND role = 'author'`,
+    [authorId]
+  );
+
+  if (existingResult.rows.length === 0) {
+    logger.warn('Author update failed: not found', { authorId });
+    throw new NotFoundError('著者が見つかりません');
+  }
+
+  const existing = mapRowToAuthorInfo(existingResult.rows[0]);
+
+  // メールアドレスを変更する場合は重複チェック
+  if (params.email && params.email !== existing.email) {
+    const emailCheck = await db.query<{ count: string }>(
+      'SELECT COUNT(*) as count FROM users WHERE email = $1 AND id != $2',
+      [params.email, authorId]
+    );
+    if (parseInt(emailCheck.rows[0].count, 10) > 0) {
+      logger.warn('Author update failed: email already exists', {
+        authorId,
+        newEmail: params.email,
+      });
+      throw new ConflictError('このメールアドレスは既に使用されています');
+    }
+  }
+
+  // 動的 SET 句を構築（変更されたフィールドのみ更新）
+  const setClauses: string[] = [];
+  const values: unknown[] = [];
+  let paramIndex = 1;
+
+  if (params.name !== undefined) {
+    setClauses.push(`name = $${paramIndex}`);
+    values.push(params.name);
+    paramIndex++;
+  }
+
+  if (params.email !== undefined) {
+    setClauses.push(`email = $${paramIndex}`);
+    values.push(params.email);
+    paramIndex++;
+  }
+
+  if (params.isActive !== undefined) {
+    setClauses.push(`is_active = $${paramIndex}`);
+    values.push(params.isActive);
+    paramIndex++;
+  }
+
+  // 更新するフィールドがない場合は現在の情報をそのまま返す
+  if (setClauses.length === 0) {
+    return existing;
+  }
+
+  // updated_at も更新する
+  setClauses.push(`updated_at = NOW()`);
+  values.push(authorId);
+
+  const updateResult = await db.query<Record<string, unknown>>(
+    `UPDATE users SET ${setClauses.join(', ')}
+     WHERE id = $${paramIndex} AND role = 'author'
+     RETURNING id, email, name, is_active, created_at, updated_at`,
+    values
+  );
+
+  const updated = mapRowToAuthorInfo(updateResult.rows[0]);
+  logger.info('Author account updated', { authorId, params });
+
+  return updated;
+}
+
+/**
+ * 著者アカウントを無効化する（論理削除）
+ *
+ * is_active フラグを false に変更する。
+ * 物理削除は行わず、無効化された著者はログインできなくなる。
+ * （auth.service.ts の is_active チェックによりログイン拒否される）
+ *
+ * @param authorId - 無効化する著者の ID（UUID）
+ * @returns 無効化後の著者情報
+ * @throws {NotFoundError} 指定 ID の著者が存在しない場合
+ *
+ * @example
+ * const deactivated = await deactivateAuthor('author-uuid-here');
+ */
+export async function deactivateAuthor(authorId: string): Promise<AuthorInfo> {
+  // 著者の存在確認
+  const existingResult = await db.query<Record<string, unknown>>(
+    `SELECT id FROM users WHERE id = $1 AND role = 'author'`,
+    [authorId]
+  );
+
+  if (existingResult.rows.length === 0) {
+    logger.warn('Author deactivation failed: not found', { authorId });
+    throw new NotFoundError('著者が見つかりません');
+  }
+
+  // is_active を false に更新（論理削除）
+  const result = await db.query<Record<string, unknown>>(
+    `UPDATE users SET is_active = false, updated_at = NOW()
+     WHERE id = $1 AND role = 'author'
+     RETURNING id, email, name, is_active, created_at, updated_at`,
+    [authorId]
+  );
+
+  const deactivated = mapRowToAuthorInfo(result.rows[0]);
+  logger.info('Author account deactivated', { authorId });
+
+  return deactivated;
+}
+
+/**
+ * adminService オブジェクト（名前空間として公開）
+ */
+export const adminService = {
+  createAuthor,
+  getAuthors,
+  getAuthorById,
+  updateAuthor,
+  deactivateAuthor,
+};

--- a/output_system/backend/src/utils/errors.ts
+++ b/output_system/backend/src/utils/errors.ts
@@ -67,3 +67,14 @@ export class ValidationError extends AppError {
     this.name = 'ValidationError';
   }
 }
+
+/**
+ * 競合エラー (409)
+ * リソースの重複や状態競合時に使用する（例: メールアドレス重複）
+ */
+export class ConflictError extends AppError {
+  constructor(message: string = 'リソースが競合しています') {
+    super(message, 409, 'CONFLICT');
+    this.name = 'ConflictError';
+  }
+}

--- a/output_system/backend/test/controllers/admin.controller.test.ts
+++ b/output_system/backend/test/controllers/admin.controller.test.ts
@@ -1,0 +1,355 @@
+/**
+ * @file admin.controller.test.ts
+ * @description 管理者コントローラーのユニットテスト
+ *
+ * テスト対象:
+ * - getAuthors: GET /api/admin/authors 著者一覧取得
+ * - createAuthor: POST /api/admin/authors 著者アカウント作成
+ * - getAuthor: GET /api/admin/authors/:id 著者詳細取得
+ * - updateAuthor: PUT /api/admin/authors/:id 著者情報更新
+ * - deactivateAuthor: DELETE /api/admin/authors/:id 著者無効化
+ *
+ * adminService をモック化して HTTP リクエスト処理のみをテストする
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { Request, Response, NextFunction } from 'express';
+
+// adminService をモック化してサービス依存を排除する
+jest.mock('../../src/services/admin.service');
+
+// DB への接続が発生しないようにモック化する
+jest.mock('../../src/config/database', () => ({
+  db: {
+    query: jest.fn(),
+    connect: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+// express-validator の validationResult をモック化
+jest.mock('express-validator', () => ({
+  ...jest.requireActual('express-validator'),
+  validationResult: jest.fn(),
+}));
+
+import {
+  getAuthors,
+  createAuthor,
+  getAuthor,
+  updateAuthor,
+  deactivateAuthor,
+} from '../../src/controllers/admin.controller';
+import { adminService } from '../../src/services/admin.service';
+import { validationResult } from 'express-validator';
+import { ConflictError, NotFoundError } from '../../src/utils/errors';
+import { AuthorInfo, AuthorDetail } from '../../src/services/admin.service';
+
+/**
+ * モック用の Express リクエストオブジェクトを生成する
+ *
+ * @param overrides - 上書きするプロパティ
+ */
+function createMockRequest(overrides: Partial<Request> = {}): Partial<Request> {
+  return {
+    user: {
+      userId: 'admin-user-id-1234',
+      email: 'admin@example.com',
+      role: 'admin',
+    },
+    params: {},
+    body: {},
+    ...overrides,
+  };
+}
+
+/**
+ * モック用の Express レスポンスオブジェクトを生成する
+ */
+function createMockResponse(): Partial<Response> {
+  const res: Partial<Response> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res;
+}
+
+/** テスト用著者データ */
+const mockAuthor: AuthorInfo = {
+  id: 'author-uuid-12345',
+  email: 'author@example.com',
+  name: 'テスト著者',
+  role: 'author',
+  isActive: true,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+/** テスト用著者詳細データ */
+const mockAuthorDetail: AuthorDetail = {
+  ...mockAuthor,
+  books: [
+    {
+      id: 'book-uuid-12345',
+      title: 'テスト書籍',
+      status: 'published',
+      format: 'pdf',
+      createdAt: new Date('2024-01-01'),
+    },
+  ],
+};
+
+describe('admin.controller', () => {
+  let mockNext: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNext = jest.fn();
+    // バリデーションエラーなしのデフォルト設定
+    (validationResult as unknown as jest.Mock).mockReturnValue({ isEmpty: () => true, array: () => [] });
+  });
+
+  // ===========================================================================
+  // getAuthors テスト
+  // ===========================================================================
+  describe('getAuthors', () => {
+    /**
+     * 【テスト対象】getAuthors コントローラー
+     * 【テスト内容】著者一覧を正常に取得できる場合
+     * 【期待結果】200 ステータスと著者一覧が返る
+     */
+    it('should return 200 with authors list', async () => {
+      // Arrange
+      const req = createMockRequest();
+      const res = createMockResponse();
+      (adminService.getAuthors as jest.Mock).mockResolvedValue([mockAuthor]);
+
+      // Act
+      await getAuthors(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        authors: [mockAuthor],
+        count: 1,
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    /**
+     * 【テスト対象】getAuthors コントローラー
+     * 【テスト内容】サービスがエラーを throw した場合
+     * 【期待結果】next にエラーが渡される
+     */
+    it('should call next with error when service throws', async () => {
+      // Arrange
+      const req = createMockRequest();
+      const res = createMockResponse();
+      const error = new Error('DB error');
+      (adminService.getAuthors as jest.Mock).mockRejectedValue(error);
+
+      // Act
+      await getAuthors(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+
+  // ===========================================================================
+  // createAuthor テスト
+  // ===========================================================================
+  describe('createAuthor', () => {
+    /**
+     * 【テスト対象】createAuthor コントローラー
+     * 【テスト内容】有効なリクエストボディで著者を作成する場合
+     * 【期待結果】201 ステータスと作成した著者情報が返る
+     */
+    it('should return 201 with created author', async () => {
+      // Arrange
+      const req = createMockRequest({
+        body: {
+          email: 'author@example.com',
+          name: 'テスト著者',
+          password: 'SecurePassword123',
+        },
+      });
+      const res = createMockResponse();
+      (adminService.createAuthor as jest.Mock).mockResolvedValue(mockAuthor);
+
+      // Act
+      await createAuthor(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ author: mockAuthor });
+    });
+
+    /**
+     * 【テスト対象】createAuthor コントローラー
+     * 【テスト内容】バリデーションエラーがある場合
+     * 【期待結果】next に ValidationError が渡される
+     */
+    it('should call next with ValidationError when validation fails', async () => {
+      // Arrange
+      const req = createMockRequest({ body: {} });
+      const res = createMockResponse();
+      (validationResult as unknown as jest.Mock).mockReturnValue({
+        isEmpty: () => false,
+        array: () => [{ msg: 'メールアドレスは必須です' }],
+      });
+
+      // Act
+      await createAuthor(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(mockNext).toHaveBeenCalled();
+      const calledError = (mockNext as jest.Mock).mock.calls[0][0];
+      expect(calledError.statusCode).toBe(400);
+    });
+
+    /**
+     * 【テスト対象】createAuthor コントローラー
+     * 【テスト内容】メールアドレスが既に使用されている場合（サービスが ConflictError を throw）
+     * 【期待結果】next に ConflictError が渡される
+     */
+    it('should call next with ConflictError when email is taken', async () => {
+      // Arrange
+      const req = createMockRequest({
+        body: {
+          email: 'taken@example.com',
+          name: 'テスト著者',
+          password: 'SecurePassword123',
+        },
+      });
+      const res = createMockResponse();
+      const conflict = new ConflictError('このメールアドレスは既に使用されています');
+      (adminService.createAuthor as jest.Mock).mockRejectedValue(conflict);
+
+      // Act
+      await createAuthor(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(mockNext).toHaveBeenCalledWith(conflict);
+    });
+  });
+
+  // ===========================================================================
+  // getAuthor テスト
+  // ===========================================================================
+  describe('getAuthor', () => {
+    /**
+     * 【テスト対象】getAuthor コントローラー
+     * 【テスト内容】存在する著者 ID を指定した場合
+     * 【期待結果】200 ステータスと著者詳細情報が返る
+     */
+    it('should return 200 with author detail', async () => {
+      // Arrange
+      const req = createMockRequest({ params: { id: 'author-uuid-12345' } });
+      const res = createMockResponse();
+      (adminService.getAuthorById as jest.Mock).mockResolvedValue(mockAuthorDetail);
+
+      // Act
+      await getAuthor(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ author: mockAuthorDetail });
+    });
+
+    /**
+     * 【テスト対象】getAuthor コントローラー
+     * 【テスト内容】存在しない著者 ID を指定した場合
+     * 【期待結果】next に NotFoundError が渡される
+     */
+    it('should call next with NotFoundError when author not found', async () => {
+      // Arrange
+      const req = createMockRequest({ params: { id: 'non-existent-uuid' } });
+      const res = createMockResponse();
+      const notFound = new NotFoundError('著者が見つかりません');
+      (adminService.getAuthorById as jest.Mock).mockRejectedValue(notFound);
+
+      // Act
+      await getAuthor(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(mockNext).toHaveBeenCalledWith(notFound);
+    });
+  });
+
+  // ===========================================================================
+  // updateAuthor テスト
+  // ===========================================================================
+  describe('updateAuthor', () => {
+    /**
+     * 【テスト対象】updateAuthor コントローラー
+     * 【テスト内容】有効なリクエストで著者情報を更新する場合
+     * 【期待結果】200 ステータスと更新後の著者情報が返る
+     */
+    it('should return 200 with updated author', async () => {
+      // Arrange
+      const updatedAuthor = { ...mockAuthor, name: '更新後の名前' };
+      const req = createMockRequest({
+        params: { id: 'author-uuid-12345' },
+        body: { name: '更新後の名前' },
+      });
+      const res = createMockResponse();
+      (adminService.updateAuthor as jest.Mock).mockResolvedValue(updatedAuthor);
+
+      // Act
+      await updateAuthor(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ author: updatedAuthor });
+    });
+  });
+
+  // ===========================================================================
+  // deactivateAuthor テスト
+  // ===========================================================================
+  describe('deactivateAuthor', () => {
+    /**
+     * 【テスト対象】deactivateAuthor コントローラー
+     * 【テスト内容】有効な著者 ID を指定した場合
+     * 【期待結果】200 ステータスと無効化後の著者情報が返る
+     */
+    it('should return 200 with deactivated author', async () => {
+      // Arrange
+      const deactivatedAuthor = { ...mockAuthor, isActive: false };
+      const req = createMockRequest({ params: { id: 'author-uuid-12345' } });
+      const res = createMockResponse();
+      (adminService.deactivateAuthor as jest.Mock).mockResolvedValue(deactivatedAuthor);
+
+      // Act
+      await deactivateAuthor(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        author: deactivatedAuthor,
+        message: '著者アカウントを無効化しました',
+      });
+    });
+
+    /**
+     * 【テスト対象】deactivateAuthor コントローラー
+     * 【テスト内容】存在しない著者 ID を指定した場合
+     * 【期待結果】next に NotFoundError が渡される
+     */
+    it('should call next with NotFoundError when author not found', async () => {
+      // Arrange
+      const req = createMockRequest({ params: { id: 'non-existent-uuid' } });
+      const res = createMockResponse();
+      const notFound = new NotFoundError('著者が見つかりません');
+      (adminService.deactivateAuthor as jest.Mock).mockRejectedValue(notFound);
+
+      // Act
+      await deactivateAuthor(req as Request, res as Response, mockNext);
+
+      // Assert
+      expect(mockNext).toHaveBeenCalledWith(notFound);
+    });
+  });
+});

--- a/output_system/backend/test/services/admin.service.test.ts
+++ b/output_system/backend/test/services/admin.service.test.ts
@@ -1,0 +1,377 @@
+/**
+ * @file admin.service.test.ts
+ * @description 管理者サービスのユニットテスト
+ *
+ * テスト対象:
+ * - adminService.createAuthor: 著者アカウント作成
+ * - adminService.getAuthors: 著者一覧取得
+ * - adminService.getAuthorById: 著者詳細取得
+ * - adminService.updateAuthor: 著者情報更新
+ * - adminService.deactivateAuthor: 著者アカウント無効化
+ *
+ * DB モックについて:
+ * jest.mock() を使って database モジュールをモック化することで DB 接続不要にする
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+// DB への接続が発生しないようにモック化する
+jest.mock('../../src/config/database', () => ({
+  db: {
+    query: jest.fn(),
+    connect: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+// crypto モジュールのハッシュ化をモック（テストで実際の bcrypt を実行しない）
+jest.mock('../../src/utils/crypto', () => ({
+  hashPassword: jest.fn().mockResolvedValue('$2a$12$mocked_hash_for_testing'),
+  verifyPassword: jest.fn().mockResolvedValue(true),
+  generateToken: jest.fn().mockReturnValue('mock-jwt-token'),
+  verifyToken: jest.fn(),
+}));
+
+import { adminService } from '../../src/services/admin.service';
+import { db } from '../../src/config/database';
+import { ConflictError, NotFoundError } from '../../src/utils/errors';
+
+// DB クエリのモック型（テスト内で型安全に使用するため）
+const mockDbQuery = db.query as jest.Mock;
+
+/** テスト用著者データ */
+const mockAuthorRow = {
+  id: 'author-uuid-12345',
+  email: 'author@example.com',
+  name: 'テスト著者',
+  role: 'author',
+  is_active: true,
+  created_at: new Date('2024-01-01'),
+  updated_at: new Date('2024-01-01'),
+};
+
+/** テスト用書籍データ */
+const mockBookRow = {
+  id: 'book-uuid-12345',
+  title: 'テスト書籍',
+  status: 'published',
+  format: 'pdf',
+  created_at: new Date('2024-01-01'),
+};
+
+describe('adminService', () => {
+  beforeEach(() => {
+    // 各テスト前にモックをリセット
+    jest.clearAllMocks();
+  });
+
+  // ===========================================================================
+  // createAuthor テスト
+  // ===========================================================================
+  describe('createAuthor', () => {
+    /**
+     * 【テスト対象】adminService.createAuthor
+     * 【テスト内容】有効なパラメータで著者アカウントを作成する
+     * 【期待結果】著者情報が返る（パスワードハッシュなし）
+     */
+    it('should create an author account with valid params', async () => {
+      // Arrange: メール重複なし → INSERT 成功
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // メール重複チェック
+        .mockResolvedValueOnce({ rows: [mockAuthorRow] }); // INSERT RETURNING
+
+      // Act
+      const result = await adminService.createAuthor({
+        email: 'author@example.com',
+        name: 'テスト著者',
+        password: 'SecurePassword123',
+      });
+
+      // Assert
+      expect(result.id).toBe('author-uuid-12345');
+      expect(result.email).toBe('author@example.com');
+      expect(result.name).toBe('テスト著者');
+      expect(result.role).toBe('author');
+      expect(result.isActive).toBe(true);
+      // パスワードハッシュが含まれていないことを確認（型の安全な確認方法）
+      expect((result as unknown as Record<string, unknown>).passwordHash).toBeUndefined();
+    });
+
+    /**
+     * 【テスト対象】adminService.createAuthor
+     * 【テスト内容】メールアドレスが既に使用されている場合
+     * 【期待結果】ConflictError が throw される
+     */
+    it('should throw ConflictError when email is already in use', async () => {
+      // Arrange: メール重複あり
+      mockDbQuery.mockResolvedValueOnce({ rows: [{ count: '1' }] });
+
+      // Act & Assert
+      await expect(
+        adminService.createAuthor({
+          email: 'existing@example.com',
+          name: '既存著者',
+          password: 'SecurePassword123',
+        })
+      ).rejects.toMatchObject({ statusCode: 409 });
+    });
+  });
+
+  // ===========================================================================
+  // getAuthors テスト
+  // ===========================================================================
+  describe('getAuthors', () => {
+    /**
+     * 【テスト対象】adminService.getAuthors
+     * 【テスト内容】著者が存在する場合
+     * 【期待結果】著者一覧が返る
+     */
+    it('should return list of authors', async () => {
+      // Arrange
+      mockDbQuery.mockResolvedValueOnce({
+        rows: [mockAuthorRow, { ...mockAuthorRow, id: 'author-uuid-67890', name: '著者B' }],
+      });
+
+      // Act
+      const result = await adminService.getAuthors();
+
+      // Assert
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('author-uuid-12345');
+      expect(result[1].id).toBe('author-uuid-67890');
+    });
+
+    /**
+     * 【テスト対象】adminService.getAuthors
+     * 【テスト内容】著者が存在しない場合
+     * 【期待結果】空配列が返る
+     */
+    it('should return empty array when no authors exist', async () => {
+      // Arrange
+      mockDbQuery.mockResolvedValueOnce({ rows: [] });
+
+      // Act
+      const result = await adminService.getAuthors();
+
+      // Assert
+      expect(result).toHaveLength(0);
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // getAuthorById テスト
+  // ===========================================================================
+  describe('getAuthorById', () => {
+    /**
+     * 【テスト対象】adminService.getAuthorById
+     * 【テスト内容】存在する著者 ID を指定した場合
+     * 【期待結果】著者詳細情報（登録書籍一覧含む）が返る
+     */
+    it('should return author detail with books', async () => {
+      // Arrange: 著者情報 → 書籍一覧
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [mockAuthorRow] })
+        .mockResolvedValueOnce({ rows: [mockBookRow] });
+
+      // Act
+      const result = await adminService.getAuthorById('author-uuid-12345');
+
+      // Assert
+      expect(result.id).toBe('author-uuid-12345');
+      expect(result.books).toHaveLength(1);
+      expect(result.books[0].id).toBe('book-uuid-12345');
+      expect(result.books[0].title).toBe('テスト書籍');
+    });
+
+    /**
+     * 【テスト対象】adminService.getAuthorById
+     * 【テスト内容】書籍がない著者を取得する場合
+     * 【期待結果】著者情報は返り、books は空配列
+     */
+    it('should return author with empty books array when no books registered', async () => {
+      // Arrange
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [mockAuthorRow] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      // Act
+      const result = await adminService.getAuthorById('author-uuid-12345');
+
+      // Assert
+      expect(result.id).toBe('author-uuid-12345');
+      expect(result.books).toHaveLength(0);
+    });
+
+    /**
+     * 【テスト対象】adminService.getAuthorById
+     * 【テスト内容】存在しない著者 ID を指定した場合
+     * 【期待結果】NotFoundError が throw される
+     */
+    it('should throw NotFoundError when author does not exist', async () => {
+      // Arrange: 著者が見つからない
+      mockDbQuery.mockResolvedValueOnce({ rows: [] });
+
+      // Act & Assert
+      await expect(adminService.getAuthorById('non-existent-uuid')).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  // ===========================================================================
+  // updateAuthor テスト
+  // ===========================================================================
+  describe('updateAuthor', () => {
+    /**
+     * 【テスト対象】adminService.updateAuthor
+     * 【テスト内容】名前を更新する場合
+     * 【期待結果】更新後の著者情報が返る
+     */
+    it('should update author name', async () => {
+      // Arrange: 著者存在確認 → UPDATE RETURNING
+      const updatedRow = { ...mockAuthorRow, name: '新しい名前' };
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [mockAuthorRow] }) // 存在確認
+        .mockResolvedValueOnce({ rows: [updatedRow] }); // UPDATE RETURNING
+
+      // Act
+      const result = await adminService.updateAuthor('author-uuid-12345', { name: '新しい名前' });
+
+      // Assert
+      expect(result.name).toBe('新しい名前');
+    });
+
+    /**
+     * 【テスト対象】adminService.updateAuthor
+     * 【テスト内容】メールアドレスを重複しない値に変更する場合
+     * 【期待結果】更新後の著者情報が返る
+     */
+    it('should update author email to a unique address', async () => {
+      // Arrange: 著者存在確認 → メール重複なし → UPDATE RETURNING
+      const updatedRow = { ...mockAuthorRow, email: 'new@example.com' };
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [mockAuthorRow] }) // 存在確認
+        .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // メール重複チェック
+        .mockResolvedValueOnce({ rows: [updatedRow] }); // UPDATE RETURNING
+
+      // Act
+      const result = await adminService.updateAuthor('author-uuid-12345', {
+        email: 'new@example.com',
+      });
+
+      // Assert
+      expect(result.email).toBe('new@example.com');
+    });
+
+    /**
+     * 【テスト対象】adminService.updateAuthor
+     * 【テスト内容】変更後のメールアドレスが既に使用されている場合
+     * 【期待結果】ConflictError が throw される
+     */
+    it('should throw ConflictError when new email is already in use', async () => {
+      // Arrange: 著者存在確認 → メール重複あり
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [mockAuthorRow] }) // 存在確認
+        .mockResolvedValueOnce({ rows: [{ count: '1' }] }); // メール重複チェック（重複あり）
+
+      // Act & Assert
+      await expect(
+        adminService.updateAuthor('author-uuid-12345', { email: 'taken@example.com' })
+      ).rejects.toMatchObject({ statusCode: 409 });
+    });
+
+    /**
+     * 【テスト対象】adminService.updateAuthor
+     * 【テスト内容】著者を無効化（isActive = false）に更新する場合
+     * 【期待結果】更新後の著者情報が返り isActive が false になっている
+     */
+    it('should deactivate author by setting isActive to false', async () => {
+      // Arrange
+      const updatedRow = { ...mockAuthorRow, is_active: false };
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [mockAuthorRow] }) // 存在確認
+        .mockResolvedValueOnce({ rows: [updatedRow] }); // UPDATE RETURNING
+
+      // Act
+      const result = await adminService.updateAuthor('author-uuid-12345', { isActive: false });
+
+      // Assert
+      expect(result.isActive).toBe(false);
+    });
+
+    /**
+     * 【テスト対象】adminService.updateAuthor
+     * 【テスト内容】存在しない著者 ID を指定した場合
+     * 【期待結果】NotFoundError が throw される
+     */
+    it('should throw NotFoundError when author does not exist', async () => {
+      // Arrange: 著者が見つからない
+      mockDbQuery.mockResolvedValueOnce({ rows: [] });
+
+      // Act & Assert
+      await expect(
+        adminService.updateAuthor('non-existent-uuid', { name: '新しい名前' })
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    /**
+     * 【テスト対象】adminService.updateAuthor
+     * 【テスト内容】更新するフィールドが指定されない場合
+     * 【期待結果】現在の著者情報がそのまま返る（DB 更新なし）
+     */
+    it('should return existing data when no fields to update', async () => {
+      // Arrange
+      mockDbQuery.mockResolvedValueOnce({ rows: [mockAuthorRow] }); // 存在確認のみ
+
+      // Act
+      const result = await adminService.updateAuthor('author-uuid-12345', {});
+
+      // Assert
+      expect(result.id).toBe('author-uuid-12345');
+      // DB への UPDATE が実行されていないことを確認
+      expect(mockDbQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // deactivateAuthor テスト
+  // ===========================================================================
+  describe('deactivateAuthor', () => {
+    /**
+     * 【テスト対象】adminService.deactivateAuthor
+     * 【テスト内容】有効な著者 ID を指定した場合
+     * 【期待結果】著者が無効化され isActive = false の著者情報が返る
+     */
+    it('should deactivate an existing author', async () => {
+      // Arrange
+      const deactivatedRow = { ...mockAuthorRow, is_active: false };
+      mockDbQuery
+        .mockResolvedValueOnce({ rows: [{ id: 'author-uuid-12345' }] }) // 存在確認
+        .mockResolvedValueOnce({ rows: [deactivatedRow] }); // UPDATE RETURNING
+
+      // Act
+      const result = await adminService.deactivateAuthor('author-uuid-12345');
+
+      // Assert
+      expect(result.id).toBe('author-uuid-12345');
+      expect(result.isActive).toBe(false);
+    });
+
+    /**
+     * 【テスト対象】adminService.deactivateAuthor
+     * 【テスト内容】存在しない著者 ID を指定した場合
+     * 【期待結果】NotFoundError が throw される
+     */
+    it('should throw NotFoundError when author does not exist', async () => {
+      // Arrange: 著者が見つからない
+      mockDbQuery.mockResolvedValueOnce({ rows: [] });
+
+      // Act & Assert
+      await expect(adminService.deactivateAuthor('non-existent-uuid')).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/output_system/frontend/src/app/admin/authors/[authorId]/page.tsx
+++ b/output_system/frontend/src/app/admin/authors/[authorId]/page.tsx
@@ -1,0 +1,651 @@
+/**
+ * @file admin/authors/[authorId]/page.tsx
+ * @description 著者詳細・編集画面
+ *
+ * 管理者が著者の詳細情報を確認し、編集・無効化を行う画面。
+ *
+ * 機能:
+ * - 著者情報の表示（名前・メール・有効/無効・登録日）
+ * - 著者情報の編集（名前・メールアドレス・有効/無効フラグ）
+ * - 著者アカウントの無効化（確認ダイアログ付き）
+ * - 著者が登録した書籍一覧の表示（読み取り専用）
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import Link from 'next/link';
+import {
+  getToken,
+  apiGetMe,
+  apiGetAuthor,
+  apiUpdateAuthor,
+  apiDeactivateAuthor,
+  AuthorDetail,
+  ApiError,
+} from '../../../../lib/api';
+import Sidebar from '../../../../components/layout/Sidebar';
+
+/**
+ * 著者詳細・編集画面コンポーネント
+ *
+ * @returns {JSX.Element} 著者詳細・編集画面
+ */
+export default function AuthorDetailPage() {
+  const router = useRouter();
+  const params = useParams();
+  const authorId = params.authorId as string;
+
+  const [author, setAuthor] = useState<AuthorDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeactivating, setIsDeactivating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // 編集フォームの状態
+  const [editName, setEditName] = useState('');
+  const [editEmail, setEditEmail] = useState('');
+  const [editIsActive, setEditIsActive] = useState(true);
+
+  // マウント時に認証確認と著者詳細を取得する
+  useEffect(() => {
+    async function init() {
+      const token = getToken();
+      if (!token) {
+        router.push('/admin/login');
+        return;
+      }
+
+      try {
+        // 認証状態と admin ロール確認
+        const meResult = await apiGetMe();
+        if (meResult.user.role !== 'admin') {
+          router.push('/admin/login');
+          return;
+        }
+
+        // 著者詳細取得
+        const result = await apiGetAuthor(authorId);
+        setAuthor(result.author);
+        // 編集フォームの初期値を設定
+        setEditName(result.author.name);
+        setEditEmail(result.author.email);
+        setEditIsActive(result.author.isActive);
+      } catch (err) {
+        const apiErr = err as ApiError;
+        if (apiErr.statusCode === 401 || apiErr.statusCode === 403) {
+          router.push('/admin/login');
+        } else if (apiErr.statusCode === 404) {
+          setError('著者が見つかりませんでした');
+        } else {
+          setError('著者詳細の取得に失敗しました');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    init();
+  }, [router, authorId]);
+
+  /**
+   * 編集モードを開始する
+   * 現在の著者情報でフォームを初期化する
+   */
+  function startEditing() {
+    if (!author) return;
+    setEditName(author.name);
+    setEditEmail(author.email);
+    setEditIsActive(author.isActive);
+    setIsEditing(true);
+    setError(null);
+    setSuccessMessage(null);
+  }
+
+  /**
+   * 編集をキャンセルする
+   */
+  function cancelEditing() {
+    setIsEditing(false);
+    setError(null);
+  }
+
+  /**
+   * 著者情報を保存するハンドラー
+   * 変更されたフィールドのみ PUT リクエストを送信する
+   */
+  async function handleSave() {
+    if (!author) return;
+
+    // クライアントサイドバリデーション
+    if (!editName.trim()) {
+      setError('名前は必須です');
+      return;
+    }
+    if (!editEmail.trim()) {
+      setError('メールアドレスは必須です');
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(editEmail)) {
+      setError('有効なメールアドレスを入力してください');
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const result = await apiUpdateAuthor(authorId, {
+        name: editName.trim(),
+        email: editEmail.trim(),
+        isActive: editIsActive,
+      });
+      // 成功: 著者情報を更新して編集モードを終了
+      setAuthor({ ...result.author, books: author.books });
+      setIsEditing(false);
+      setSuccessMessage('著者情報を更新しました');
+      // 3 秒後に成功メッセージを消す
+      setTimeout(() => setSuccessMessage(null), 3000);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr.message || '更新に失敗しました');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  /**
+   * 著者アカウント無効化ハンドラー
+   * 確認ダイアログを表示し、確認後に無効化 API を呼び出す
+   */
+  async function handleDeactivate() {
+    if (!author) return;
+
+    const confirmed = window.confirm(
+      `「${author.name}」のアカウントを無効化しますか？\n無効化すると、この著者はログインできなくなります。`
+    );
+    if (!confirmed) return;
+
+    setIsDeactivating(true);
+    setError(null);
+
+    try {
+      const result = await apiDeactivateAuthor(authorId);
+      setAuthor({ ...result.author, books: author.books });
+      setSuccessMessage('著者アカウントを無効化しました');
+      setTimeout(() => setSuccessMessage(null), 3000);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr.message || '無効化に失敗しました');
+    } finally {
+      setIsDeactivating(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100vh' }}>
+        <Sidebar />
+        <main style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <p style={{ color: '#6b7280' }}>読み込み中...</p>
+        </main>
+      </div>
+    );
+  }
+
+  if (!author && error) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100vh' }}>
+        <Sidebar />
+        <main style={{ flex: 1, padding: '2rem' }}>
+          <div
+            style={{
+              padding: '1rem',
+              backgroundColor: '#fef2f2',
+              border: '1px solid #fecaca',
+              borderRadius: '8px',
+              color: '#dc2626',
+            }}
+          >
+            {error}
+          </div>
+          <Link
+            href="/admin/authors"
+            style={{ display: 'inline-block', marginTop: '1rem', color: '#2563eb' }}
+          >
+            ← 著者一覧に戻る
+          </Link>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh', backgroundColor: '#f8fafc' }}>
+      {/* サイドバーナビゲーション */}
+      <Sidebar />
+
+      {/* メインコンテンツ */}
+      <main style={{ flex: 1, padding: '2rem', overflowY: 'auto' }}>
+        {/* パンくずナビゲーション */}
+        <nav style={{ marginBottom: '1.5rem', fontSize: '0.875rem', color: '#6b7280' }}>
+          <Link href="/admin/authors" style={{ color: '#2563eb', textDecoration: 'none' }}>
+            著者管理
+          </Link>
+          <span style={{ margin: '0 0.5rem' }}>/</span>
+          <span>{author?.name}</span>
+        </nav>
+
+        {/* ページヘッダー */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            marginBottom: '1.5rem',
+          }}
+        >
+          <h1 style={{ fontSize: '1.6rem', fontWeight: '700', color: '#111827', margin: 0 }}>
+            著者詳細
+          </h1>
+          <div style={{ display: 'flex', gap: '0.75rem' }}>
+            {/* 編集ボタン（編集モードでなく、著者が有効な場合のみ表示） */}
+            {!isEditing && author?.isActive && (
+              <button
+                onClick={startEditing}
+                style={{
+                  padding: '0.5rem 1rem',
+                  border: '1px solid #d1d5db',
+                  borderRadius: '8px',
+                  backgroundColor: '#fff',
+                  color: '#374151',
+                  cursor: 'pointer',
+                  fontSize: '0.9rem',
+                }}
+              >
+                編集
+              </button>
+            )}
+            {/* 無効化ボタン（著者が有効な場合のみ表示） */}
+            {author?.isActive && !isEditing && (
+              <button
+                onClick={handleDeactivate}
+                disabled={isDeactivating}
+                style={{
+                  padding: '0.5rem 1rem',
+                  border: '1px solid #fca5a5',
+                  borderRadius: '8px',
+                  backgroundColor: '#fff',
+                  color: '#dc2626',
+                  cursor: isDeactivating ? 'not-allowed' : 'pointer',
+                  fontSize: '0.9rem',
+                  opacity: isDeactivating ? 0.6 : 1,
+                }}
+              >
+                {isDeactivating ? '処理中...' : '無効化'}
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* 成功メッセージ */}
+        {successMessage && (
+          <div
+            style={{
+              padding: '0.75rem 1rem',
+              backgroundColor: '#f0fdf4',
+              border: '1px solid #86efac',
+              borderRadius: '8px',
+              color: '#16a34a',
+              marginBottom: '1rem',
+              fontSize: '0.9rem',
+            }}
+          >
+            {successMessage}
+          </div>
+        )}
+
+        {/* エラーメッセージ */}
+        {error && (
+          <div
+            style={{
+              padding: '0.75rem 1rem',
+              backgroundColor: '#fef2f2',
+              border: '1px solid #fecaca',
+              borderRadius: '8px',
+              color: '#dc2626',
+              marginBottom: '1rem',
+              fontSize: '0.9rem',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: 'grid', gap: '1.5rem', gridTemplateColumns: '1fr 1fr' }}>
+          {/* 著者情報カード */}
+          <div
+            style={{
+              backgroundColor: '#fff',
+              border: '1px solid #e5e7eb',
+              borderRadius: '12px',
+              padding: '1.5rem',
+            }}
+          >
+            <h2 style={{ fontSize: '1rem', fontWeight: '700', color: '#374151', marginBottom: '1.25rem' }}>
+              著者情報
+            </h2>
+
+            {isEditing ? (
+              // 編集フォーム
+              <div>
+                {/* 名前入力 */}
+                <div style={{ marginBottom: '1rem' }}>
+                  <label
+                    style={{
+                      display: 'block',
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      marginBottom: '0.375rem',
+                    }}
+                  >
+                    名前
+                  </label>
+                  <input
+                    type="text"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    maxLength={100}
+                    style={{
+                      width: '100%',
+                      padding: '0.5rem 0.75rem',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '6px',
+                      fontSize: '0.9rem',
+                      boxSizing: 'border-box',
+                    }}
+                  />
+                </div>
+
+                {/* メールアドレス入力 */}
+                <div style={{ marginBottom: '1rem' }}>
+                  <label
+                    style={{
+                      display: 'block',
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      marginBottom: '0.375rem',
+                    }}
+                  >
+                    メールアドレス
+                  </label>
+                  <input
+                    type="email"
+                    value={editEmail}
+                    onChange={(e) => setEditEmail(e.target.value)}
+                    style={{
+                      width: '100%',
+                      padding: '0.5rem 0.75rem',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '6px',
+                      fontSize: '0.9rem',
+                      boxSizing: 'border-box',
+                    }}
+                  />
+                </div>
+
+                {/* 有効/無効フラグ */}
+                <div style={{ marginBottom: '1.5rem' }}>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                    <input
+                      type="checkbox"
+                      checked={editIsActive}
+                      onChange={(e) => setEditIsActive(e.target.checked)}
+                      style={{ width: '16px', height: '16px' }}
+                    />
+                    <span style={{ fontSize: '0.9rem', color: '#374151' }}>アカウントを有効にする</span>
+                  </label>
+                </div>
+
+                {/* 保存/キャンセルボタン */}
+                <div style={{ display: 'flex', gap: '0.5rem' }}>
+                  <button
+                    onClick={handleSave}
+                    disabled={isSaving}
+                    style={{
+                      padding: '0.5rem 1rem',
+                      backgroundColor: isSaving ? '#93c5fd' : '#2563eb',
+                      color: '#fff',
+                      border: 'none',
+                      borderRadius: '6px',
+                      cursor: isSaving ? 'not-allowed' : 'pointer',
+                      fontSize: '0.875rem',
+                      fontWeight: '600',
+                    }}
+                  >
+                    {isSaving ? '保存中...' : '保存'}
+                  </button>
+                  <button
+                    onClick={cancelEditing}
+                    disabled={isSaving}
+                    style={{
+                      padding: '0.5rem 1rem',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '6px',
+                      backgroundColor: '#fff',
+                      color: '#374151',
+                      cursor: 'pointer',
+                      fontSize: '0.875rem',
+                    }}
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </div>
+            ) : (
+              // 表示モード
+              <dl style={{ margin: 0 }}>
+                {/* 名前 */}
+                <div style={{ marginBottom: '1rem' }}>
+                  <dt
+                    style={{
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    名前
+                  </dt>
+                  <dd style={{ fontSize: '0.95rem', color: '#111827', margin: 0 }}>
+                    {author?.name}
+                  </dd>
+                </div>
+                {/* メールアドレス */}
+                <div style={{ marginBottom: '1rem' }}>
+                  <dt
+                    style={{
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    メールアドレス
+                  </dt>
+                  <dd style={{ fontSize: '0.95rem', color: '#111827', margin: 0 }}>
+                    {author?.email}
+                  </dd>
+                </div>
+                {/* ステータス */}
+                <div style={{ marginBottom: '1rem' }}>
+                  <dt
+                    style={{
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    ステータス
+                  </dt>
+                  <dd style={{ margin: 0 }}>
+                    <span
+                      style={{
+                        display: 'inline-block',
+                        padding: '0.25rem 0.625rem',
+                        borderRadius: '9999px',
+                        fontSize: '0.75rem',
+                        fontWeight: '600',
+                        backgroundColor: author?.isActive ? '#dcfce7' : '#fee2e2',
+                        color: author?.isActive ? '#16a34a' : '#dc2626',
+                      }}
+                    >
+                      {author?.isActive ? '有効' : '無効'}
+                    </span>
+                  </dd>
+                </div>
+                {/* 登録日 */}
+                <div style={{ marginBottom: '1rem' }}>
+                  <dt
+                    style={{
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    登録日
+                  </dt>
+                  <dd style={{ fontSize: '0.95rem', color: '#111827', margin: 0 }}>
+                    {author?.createdAt
+                      ? new Date(author.createdAt).toLocaleDateString('ja-JP')
+                      : '-'}
+                  </dd>
+                </div>
+                {/* 更新日 */}
+                <div>
+                  <dt
+                    style={{
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      marginBottom: '0.25rem',
+                    }}
+                  >
+                    最終更新日
+                  </dt>
+                  <dd style={{ fontSize: '0.95rem', color: '#111827', margin: 0 }}>
+                    {author?.updatedAt
+                      ? new Date(author.updatedAt).toLocaleDateString('ja-JP')
+                      : '-'}
+                  </dd>
+                </div>
+              </dl>
+            )}
+          </div>
+
+          {/* 登録書籍一覧カード */}
+          <div
+            style={{
+              backgroundColor: '#fff',
+              border: '1px solid #e5e7eb',
+              borderRadius: '12px',
+              padding: '1.5rem',
+            }}
+          >
+            <h2 style={{ fontSize: '1rem', fontWeight: '700', color: '#374151', marginBottom: '1.25rem' }}>
+              登録書籍 ({author?.books?.length ?? 0} 件)
+            </h2>
+
+            {!author?.books || author.books.length === 0 ? (
+              // 書籍がない場合の空状態
+              <p style={{ color: '#9ca3af', fontSize: '0.9rem', textAlign: 'center', padding: '1.5rem 0' }}>
+                登録された書籍はありません
+              </p>
+            ) : (
+              <div>
+                {author.books.map((book, index) => (
+                  <div
+                    key={book.id}
+                    style={{
+                      padding: '0.75rem 0',
+                      borderBottom:
+                        index < author.books.length - 1 ? '1px solid #f3f4f6' : 'none',
+                    }}
+                  >
+                    {/* 書籍タイトルとステータス */}
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'flex-start',
+                      }}
+                    >
+                      <span style={{ fontSize: '0.9rem', color: '#111827', fontWeight: '500' }}>
+                        {book.title}
+                      </span>
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          padding: '0.2rem 0.5rem',
+                          borderRadius: '4px',
+                          fontSize: '0.7rem',
+                          fontWeight: '600',
+                          backgroundColor:
+                            book.status === 'published'
+                              ? '#dcfce7'
+                              : book.status === 'draft'
+                              ? '#fef3c7'
+                              : '#f3f4f6',
+                          color:
+                            book.status === 'published'
+                              ? '#16a34a'
+                              : book.status === 'draft'
+                              ? '#b45309'
+                              : '#6b7280',
+                          flexShrink: 0,
+                          marginLeft: '0.5rem',
+                        }}
+                      >
+                        {book.status === 'published'
+                          ? '公開中'
+                          : book.status === 'draft'
+                          ? '下書き'
+                          : 'アーカイブ'}
+                      </span>
+                    </div>
+                    {/* 書籍メタ情報 */}
+                    <div style={{ marginTop: '0.25rem', display: 'flex', gap: '0.75rem' }}>
+                      <span style={{ fontSize: '0.75rem', color: '#9ca3af' }}>
+                        形式: {book.format?.toUpperCase() ?? '-'}
+                      </span>
+                      <span style={{ fontSize: '0.75rem', color: '#9ca3af' }}>
+                        登録: {new Date(book.createdAt).toLocaleDateString('ja-JP')}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 著者一覧に戻るリンク */}
+        <div style={{ marginTop: '1.5rem' }}>
+          <Link
+            href="/admin/authors"
+            style={{ color: '#2563eb', textDecoration: 'none', fontSize: '0.9rem' }}
+          >
+            ← 著者一覧に戻る
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/output_system/frontend/src/app/admin/authors/new/page.tsx
+++ b/output_system/frontend/src/app/admin/authors/new/page.tsx
@@ -1,0 +1,414 @@
+/**
+ * @file admin/authors/new/page.tsx
+ * @description 著者アカウント新規作成画面
+ *
+ * 管理者が新しい著者アカウントを作成するフォーム画面。
+ *
+ * 機能:
+ * - メールアドレス・名前・初期パスワードの入力フォーム
+ * - フロントエンドバリデーション（必須チェック・メール形式・パスワード長）
+ * - 作成成功後に著者一覧画面にリダイレクト
+ * - API エラー（メール重複等）のインライン表示
+ */
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { getToken, apiGetMe, apiCreateAuthor, ApiError } from '../../../../lib/api';
+import Sidebar from '../../../../components/layout/Sidebar';
+
+/**
+ * フォーム入力値の型定義
+ */
+interface FormData {
+  email: string;
+  name: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+/**
+ * フォームバリデーションエラーの型定義
+ */
+interface FormErrors {
+  email?: string;
+  name?: string;
+  password?: string;
+  passwordConfirm?: string;
+}
+
+/**
+ * 著者アカウント新規作成画面コンポーネント
+ *
+ * @returns {JSX.Element} 著者作成フォーム画面
+ */
+export default function NewAuthorPage() {
+  const router = useRouter();
+  const [isAuthChecking, setIsAuthChecking] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [formData, setFormData] = useState<FormData>({
+    email: '',
+    name: '',
+    password: '',
+    passwordConfirm: '',
+  });
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+
+  // 認証状態確認
+  useEffect(() => {
+    async function checkAuth() {
+      const token = getToken();
+      if (!token) {
+        router.push('/admin/login');
+        return;
+      }
+
+      try {
+        const meResult = await apiGetMe();
+        if (meResult.user.role !== 'admin') {
+          router.push('/admin/login');
+          return;
+        }
+      } catch {
+        router.push('/admin/login');
+      } finally {
+        setIsAuthChecking(false);
+      }
+    }
+    checkAuth();
+  }, [router]);
+
+  /**
+   * フォーム入力値を変更するハンドラー
+   *
+   * @param field - 変更するフィールド名
+   * @param value - 新しい値
+   */
+  function handleChange(field: keyof FormData, value: string) {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    // 入力時にそのフィールドのエラーをクリア
+    setFormErrors((prev) => ({ ...prev, [field]: undefined }));
+    setApiError(null);
+  }
+
+  /**
+   * フォームのバリデーションを実行する
+   *
+   * @returns バリデーションが通った場合は true
+   */
+  function validate(): boolean {
+    const errors: FormErrors = {};
+
+    // メールアドレス検証
+    if (!formData.email.trim()) {
+      errors.email = 'メールアドレスは必須です';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      errors.email = '有効なメールアドレスを入力してください';
+    }
+
+    // 名前検証
+    if (!formData.name.trim()) {
+      errors.name = '名前は必須です';
+    } else if (formData.name.trim().length > 100) {
+      errors.name = '名前は 100 文字以内で入力してください';
+    }
+
+    // パスワード検証
+    if (!formData.password) {
+      errors.password = 'パスワードは必須です';
+    } else if (formData.password.length < 8) {
+      errors.password = 'パスワードは 8 文字以上で入力してください';
+    }
+
+    // パスワード確認検証
+    if (!formData.passwordConfirm) {
+      errors.passwordConfirm = 'パスワード確認は必須です';
+    } else if (formData.password !== formData.passwordConfirm) {
+      errors.passwordConfirm = 'パスワードが一致しません';
+    }
+
+    setFormErrors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  /**
+   * フォーム送信ハンドラー
+   * バリデーション後に著者アカウント作成 API を呼び出す
+   */
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!validate()) return;
+
+    setIsSubmitting(true);
+    setApiError(null);
+
+    try {
+      await apiCreateAuthor(formData.email.trim(), formData.name.trim(), formData.password);
+      // 作成成功: 著者一覧画面にリダイレクト
+      router.push('/admin/authors');
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setApiError(apiErr.message || '著者アカウントの作成に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (isAuthChecking) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100vh' }}>
+        <Sidebar />
+        <main style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <p style={{ color: '#6b7280' }}>読み込み中...</p>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh', backgroundColor: '#f8fafc' }}>
+      {/* サイドバーナビゲーション */}
+      <Sidebar />
+
+      {/* メインコンテンツ */}
+      <main style={{ flex: 1, padding: '2rem', overflowY: 'auto' }}>
+        {/* パンくずナビゲーション */}
+        <nav style={{ marginBottom: '1.5rem', fontSize: '0.875rem', color: '#6b7280' }}>
+          <Link href="/admin/authors" style={{ color: '#2563eb', textDecoration: 'none' }}>
+            著者管理
+          </Link>
+          <span style={{ margin: '0 0.5rem' }}>/</span>
+          <span>新規著者を追加</span>
+        </nav>
+
+        {/* ページヘッダー */}
+        <h1 style={{ fontSize: '1.6rem', fontWeight: '700', color: '#111827', marginBottom: '1.5rem' }}>
+          新規著者を追加
+        </h1>
+
+        {/* 作成フォームカード */}
+        <div
+          style={{
+            maxWidth: '520px',
+            backgroundColor: '#fff',
+            border: '1px solid #e5e7eb',
+            borderRadius: '12px',
+            padding: '2rem',
+          }}
+        >
+          {/* API エラーメッセージ */}
+          {apiError && (
+            <div
+              style={{
+                padding: '0.75rem 1rem',
+                backgroundColor: '#fef2f2',
+                border: '1px solid #fecaca',
+                borderRadius: '8px',
+                color: '#dc2626',
+                marginBottom: '1.5rem',
+                fontSize: '0.9rem',
+              }}
+            >
+              {apiError}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            {/* メールアドレス入力 */}
+            <div style={{ marginBottom: '1.25rem' }}>
+              <label
+                htmlFor="email"
+                style={{
+                  display: 'block',
+                  fontSize: '0.875rem',
+                  fontWeight: '600',
+                  color: '#374151',
+                  marginBottom: '0.375rem',
+                }}
+              >
+                メールアドレス <span style={{ color: '#dc2626' }}>*</span>
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={formData.email}
+                onChange={(e) => handleChange('email', e.target.value)}
+                placeholder="author@example.com"
+                style={{
+                  width: '100%',
+                  padding: '0.625rem 0.75rem',
+                  border: `1px solid ${formErrors.email ? '#fca5a5' : '#d1d5db'}`,
+                  borderRadius: '8px',
+                  fontSize: '0.9rem',
+                  outline: 'none',
+                  boxSizing: 'border-box',
+                }}
+              />
+              {formErrors.email && (
+                <p style={{ color: '#dc2626', fontSize: '0.8rem', marginTop: '0.25rem' }}>
+                  {formErrors.email}
+                </p>
+              )}
+            </div>
+
+            {/* 名前入力 */}
+            <div style={{ marginBottom: '1.25rem' }}>
+              <label
+                htmlFor="name"
+                style={{
+                  display: 'block',
+                  fontSize: '0.875rem',
+                  fontWeight: '600',
+                  color: '#374151',
+                  marginBottom: '0.375rem',
+                }}
+              >
+                名前 <span style={{ color: '#dc2626' }}>*</span>
+              </label>
+              <input
+                id="name"
+                type="text"
+                value={formData.name}
+                onChange={(e) => handleChange('name', e.target.value)}
+                placeholder="山田 太郎"
+                maxLength={100}
+                style={{
+                  width: '100%',
+                  padding: '0.625rem 0.75rem',
+                  border: `1px solid ${formErrors.name ? '#fca5a5' : '#d1d5db'}`,
+                  borderRadius: '8px',
+                  fontSize: '0.9rem',
+                  outline: 'none',
+                  boxSizing: 'border-box',
+                }}
+              />
+              {formErrors.name && (
+                <p style={{ color: '#dc2626', fontSize: '0.8rem', marginTop: '0.25rem' }}>
+                  {formErrors.name}
+                </p>
+              )}
+            </div>
+
+            {/* パスワード入力 */}
+            <div style={{ marginBottom: '1.25rem' }}>
+              <label
+                htmlFor="password"
+                style={{
+                  display: 'block',
+                  fontSize: '0.875rem',
+                  fontWeight: '600',
+                  color: '#374151',
+                  marginBottom: '0.375rem',
+                }}
+              >
+                初期パスワード <span style={{ color: '#dc2626' }}>*</span>
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={formData.password}
+                onChange={(e) => handleChange('password', e.target.value)}
+                placeholder="8文字以上"
+                style={{
+                  width: '100%',
+                  padding: '0.625rem 0.75rem',
+                  border: `1px solid ${formErrors.password ? '#fca5a5' : '#d1d5db'}`,
+                  borderRadius: '8px',
+                  fontSize: '0.9rem',
+                  outline: 'none',
+                  boxSizing: 'border-box',
+                }}
+              />
+              {formErrors.password && (
+                <p style={{ color: '#dc2626', fontSize: '0.8rem', marginTop: '0.25rem' }}>
+                  {formErrors.password}
+                </p>
+              )}
+            </div>
+
+            {/* パスワード確認入力 */}
+            <div style={{ marginBottom: '1.75rem' }}>
+              <label
+                htmlFor="passwordConfirm"
+                style={{
+                  display: 'block',
+                  fontSize: '0.875rem',
+                  fontWeight: '600',
+                  color: '#374151',
+                  marginBottom: '0.375rem',
+                }}
+              >
+                パスワード確認 <span style={{ color: '#dc2626' }}>*</span>
+              </label>
+              <input
+                id="passwordConfirm"
+                type="password"
+                value={formData.passwordConfirm}
+                onChange={(e) => handleChange('passwordConfirm', e.target.value)}
+                placeholder="パスワードを再入力"
+                style={{
+                  width: '100%',
+                  padding: '0.625rem 0.75rem',
+                  border: `1px solid ${formErrors.passwordConfirm ? '#fca5a5' : '#d1d5db'}`,
+                  borderRadius: '8px',
+                  fontSize: '0.9rem',
+                  outline: 'none',
+                  boxSizing: 'border-box',
+                }}
+              />
+              {formErrors.passwordConfirm && (
+                <p style={{ color: '#dc2626', fontSize: '0.8rem', marginTop: '0.25rem' }}>
+                  {formErrors.passwordConfirm}
+                </p>
+              )}
+            </div>
+
+            {/* フォーム操作ボタン */}
+            <div style={{ display: 'flex', gap: '0.75rem' }}>
+              {/* 作成ボタン */}
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                style={{
+                  flex: 1,
+                  padding: '0.75rem',
+                  backgroundColor: isSubmitting ? '#93c5fd' : '#2563eb',
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: '8px',
+                  fontSize: '0.9rem',
+                  fontWeight: '600',
+                  cursor: isSubmitting ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {isSubmitting ? '作成中...' : '著者アカウントを作成'}
+              </button>
+              {/* キャンセルボタン */}
+              <Link
+                href="/admin/authors"
+                style={{
+                  display: 'block',
+                  padding: '0.75rem 1.25rem',
+                  border: '1px solid #d1d5db',
+                  borderRadius: '8px',
+                  backgroundColor: '#fff',
+                  color: '#374151',
+                  textDecoration: 'none',
+                  fontSize: '0.9rem',
+                  textAlign: 'center',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                キャンセル
+              </Link>
+            </div>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/output_system/frontend/src/app/admin/authors/page.tsx
+++ b/output_system/frontend/src/app/admin/authors/page.tsx
@@ -1,0 +1,384 @@
+/**
+ * @file admin/authors/page.tsx
+ * @description 著者一覧画面
+ *
+ * 管理者が著者アカウントの一覧を確認し、
+ * 著者の詳細・編集・無効化を行うエントリーポイント。
+ *
+ * 機能:
+ * - 著者一覧をテーブル形式で表示（名前・メール・有効/無効・登録日）
+ * - 新規著者作成ボタン
+ * - 著者詳細ページへのリンク
+ * - 著者アカウントの無効化（確認ダイアログ付き）
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  getToken,
+  apiGetMe,
+  apiGetAuthors,
+  apiDeactivateAuthor,
+  AuthorInfo,
+  ApiError,
+} from '../../../lib/api';
+import Sidebar from '../../../components/layout/Sidebar';
+
+/**
+ * 著者一覧画面コンポーネント
+ *
+ * @returns {JSX.Element} 著者一覧画面
+ */
+export default function AuthorsPage() {
+  const router = useRouter();
+  const [authors, setAuthors] = useState<AuthorInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deactivatingId, setDeactivatingId] = useState<string | null>(null);
+
+  // マウント時に認証状態確認と著者一覧を取得する
+  useEffect(() => {
+    async function init() {
+      const token = getToken();
+      if (!token) {
+        router.push('/admin/login');
+        return;
+      }
+
+      try {
+        // 認証状態と admin ロール確認
+        const meResult = await apiGetMe();
+        if (meResult.user.role !== 'admin') {
+          router.push('/admin/login');
+          return;
+        }
+
+        // 著者一覧取得
+        const result = await apiGetAuthors();
+        setAuthors(result.authors);
+      } catch (err) {
+        const apiErr = err as ApiError;
+        if (apiErr.statusCode === 401 || apiErr.statusCode === 403) {
+          router.push('/admin/login');
+        } else {
+          setError('著者一覧の取得に失敗しました');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    init();
+  }, [router]);
+
+  /**
+   * 著者アカウント無効化ハンドラー
+   * 確認ダイアログを表示し、確認後に無効化 API を呼び出す
+   *
+   * @param authorId - 無効化する著者の ID
+   * @param authorName - 著者名（確認ダイアログ用）
+   */
+  async function handleDeactivate(authorId: string, authorName: string) {
+    // 確認ダイアログを表示（誤操作防止）
+    const confirmed = window.confirm(
+      `「${authorName}」のアカウントを無効化しますか？\n無効化すると、この著者はログインできなくなります。`
+    );
+    if (!confirmed) return;
+
+    setDeactivatingId(authorId);
+    try {
+      await apiDeactivateAuthor(authorId);
+      // 無効化成功: 一覧を更新
+      setAuthors((prev) =>
+        prev.map((a) => (a.id === authorId ? { ...a, isActive: false } : a))
+      );
+    } catch (err) {
+      const apiErr = err as ApiError;
+      setError(apiErr.message || '無効化に失敗しました');
+    } finally {
+      setDeactivatingId(null);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ display: 'flex', minHeight: '100vh' }}>
+        <Sidebar />
+        <main style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <p style={{ color: '#6b7280' }}>読み込み中...</p>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh', backgroundColor: '#f8fafc' }}>
+      {/* サイドバーナビゲーション */}
+      <Sidebar />
+
+      {/* メインコンテンツ */}
+      <main style={{ flex: 1, padding: '2rem', overflowY: 'auto' }}>
+        {/* ページヘッダー */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '1.5rem',
+          }}
+        >
+          <div>
+            <h1 style={{ fontSize: '1.6rem', fontWeight: '700', color: '#111827', margin: 0 }}>
+              著者管理
+            </h1>
+            <p style={{ color: '#6b7280', marginTop: '0.25rem', fontSize: '0.9rem' }}>
+              著者アカウントの作成・編集・無効化を行います
+            </p>
+          </div>
+          {/* 新規著者作成ボタン */}
+          <Link
+            href="/admin/authors/new"
+            style={{
+              display: 'inline-block',
+              padding: '0.625rem 1.25rem',
+              backgroundColor: '#2563eb',
+              color: '#fff',
+              borderRadius: '8px',
+              textDecoration: 'none',
+              fontWeight: '600',
+              fontSize: '0.9rem',
+            }}
+          >
+            + 新規著者を追加
+          </Link>
+        </div>
+
+        {/* エラーメッセージ */}
+        {error && (
+          <div
+            style={{
+              padding: '0.75rem 1rem',
+              backgroundColor: '#fef2f2',
+              border: '1px solid #fecaca',
+              borderRadius: '8px',
+              color: '#dc2626',
+              marginBottom: '1rem',
+              fontSize: '0.9rem',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* 著者一覧テーブル */}
+        <div
+          style={{
+            backgroundColor: '#fff',
+            border: '1px solid #e5e7eb',
+            borderRadius: '12px',
+            overflow: 'hidden',
+          }}
+        >
+          {authors.length === 0 ? (
+            // 著者が存在しない場合の空状態
+            <div
+              style={{
+                padding: '3rem',
+                textAlign: 'center',
+                color: '#9ca3af',
+              }}
+            >
+              <p style={{ fontSize: '1rem' }}>著者アカウントがまだありません</p>
+              <Link
+                href="/admin/authors/new"
+                style={{
+                  display: 'inline-block',
+                  marginTop: '1rem',
+                  padding: '0.5rem 1rem',
+                  backgroundColor: '#2563eb',
+                  color: '#fff',
+                  borderRadius: '6px',
+                  textDecoration: 'none',
+                  fontSize: '0.9rem',
+                }}
+              >
+                最初の著者を追加
+              </Link>
+            </div>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ backgroundColor: '#f9fafb', borderBottom: '1px solid #e5e7eb' }}>
+                  <th
+                    style={{
+                      padding: '0.875rem 1rem',
+                      textAlign: 'left',
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    名前
+                  </th>
+                  <th
+                    style={{
+                      padding: '0.875rem 1rem',
+                      textAlign: 'left',
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    メールアドレス
+                  </th>
+                  <th
+                    style={{
+                      padding: '0.875rem 1rem',
+                      textAlign: 'center',
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    ステータス
+                  </th>
+                  <th
+                    style={{
+                      padding: '0.875rem 1rem',
+                      textAlign: 'left',
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    登録日
+                  </th>
+                  <th
+                    style={{
+                      padding: '0.875rem 1rem',
+                      textAlign: 'center',
+                      fontSize: '0.8rem',
+                      fontWeight: '600',
+                      color: '#6b7280',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                    }}
+                  >
+                    操作
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {authors.map((author, index) => (
+                  <tr
+                    key={author.id}
+                    style={{
+                      borderBottom:
+                        index < authors.length - 1 ? '1px solid #f3f4f6' : 'none',
+                    }}
+                  >
+                    {/* 名前（著者詳細へのリンク） */}
+                    <td style={{ padding: '1rem' }}>
+                      <Link
+                        href={`/admin/authors/${author.id}`}
+                        style={{
+                          color: '#2563eb',
+                          textDecoration: 'none',
+                          fontWeight: '500',
+                        }}
+                      >
+                        {author.name}
+                      </Link>
+                    </td>
+                    {/* メールアドレス */}
+                    <td style={{ padding: '1rem', color: '#374151', fontSize: '0.9rem' }}>
+                      {author.email}
+                    </td>
+                    {/* ステータスバッジ */}
+                    <td style={{ padding: '1rem', textAlign: 'center' }}>
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          padding: '0.25rem 0.625rem',
+                          borderRadius: '9999px',
+                          fontSize: '0.75rem',
+                          fontWeight: '600',
+                          backgroundColor: author.isActive ? '#dcfce7' : '#fee2e2',
+                          color: author.isActive ? '#16a34a' : '#dc2626',
+                        }}
+                      >
+                        {author.isActive ? '有効' : '無効'}
+                      </span>
+                    </td>
+                    {/* 登録日 */}
+                    <td style={{ padding: '1rem', color: '#6b7280', fontSize: '0.875rem' }}>
+                      {new Date(author.createdAt).toLocaleDateString('ja-JP')}
+                    </td>
+                    {/* 操作ボタン */}
+                    <td style={{ padding: '1rem', textAlign: 'center' }}>
+                      <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+                        {/* 詳細・編集ボタン */}
+                        <Link
+                          href={`/admin/authors/${author.id}`}
+                          style={{
+                            padding: '0.375rem 0.75rem',
+                            border: '1px solid #d1d5db',
+                            borderRadius: '6px',
+                            backgroundColor: '#fff',
+                            color: '#374151',
+                            textDecoration: 'none',
+                            fontSize: '0.8rem',
+                          }}
+                        >
+                          詳細
+                        </Link>
+                        {/* 無効化ボタン（有効な著者のみ表示） */}
+                        {author.isActive && (
+                          <button
+                            onClick={() => handleDeactivate(author.id, author.name)}
+                            disabled={deactivatingId === author.id}
+                            style={{
+                              padding: '0.375rem 0.75rem',
+                              border: '1px solid #fca5a5',
+                              borderRadius: '6px',
+                              backgroundColor: '#fff',
+                              color: '#dc2626',
+                              cursor: deactivatingId === author.id ? 'not-allowed' : 'pointer',
+                              fontSize: '0.8rem',
+                              opacity: deactivatingId === author.id ? 0.6 : 1,
+                            }}
+                          >
+                            {deactivatingId === author.id ? '処理中...' : '無効化'}
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* 著者数サマリー */}
+        {authors.length > 0 && (
+          <p style={{ marginTop: '1rem', color: '#9ca3af', fontSize: '0.85rem' }}>
+            合計 {authors.length} 件（有効: {authors.filter((a) => a.isActive).length} 件、
+            無効: {authors.filter((a) => !a.isActive).length} 件）
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/output_system/frontend/src/app/admin/dashboard/page.tsx
+++ b/output_system/frontend/src/app/admin/dashboard/page.tsx
@@ -1,16 +1,18 @@
 /**
  * @file admin/dashboard/page.tsx
- * @description 管理者ダッシュボード（プレースホルダー）
+ * @description 管理者ダッシュボード
  *
- * ログイン後の管理者向け画面。
- * 後続のPBIで本実装を行う。
+ * ログイン後の管理者向けトップ画面。
+ * 管理機能へのナビゲーションとサマリー情報を提供する。
  */
 
 'use client';
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { getToken, apiGetMe, apiLogout, AuthUser } from '../../../lib/api';
+import Sidebar from '../../../components/layout/Sidebar';
 
 /**
  * 管理者ダッシュボードコンポーネント
@@ -56,34 +58,83 @@ export default function AdminDashboard() {
 
   if (isLoading) {
     return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
-        <p>読み込み中...</p>
+      <div style={{ display: 'flex', minHeight: '100vh' }}>
+        <div style={{ width: '240px', backgroundColor: '#1e293b' }} />
+        <div style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <p style={{ color: '#6b7280' }}>読み込み中...</p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div style={{ padding: '2rem', maxWidth: '1200px', margin: '0 auto' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem' }}>
-        <h1 style={{ fontSize: '1.8rem', color: '#111' }}>管理ダッシュボード</h1>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-          <span style={{ color: '#555' }}>{user?.name}（管理者）</span>
+    <div style={{ display: 'flex', minHeight: '100vh', backgroundColor: '#f8fafc' }}>
+      {/* サイドバーナビゲーション */}
+      <Sidebar />
+
+      {/* メインコンテンツ */}
+      <main style={{ flex: 1, padding: '2rem', overflowY: 'auto' }}>
+        {/* ページヘッダー */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '2rem',
+          }}
+        >
+          <div>
+            <h1 style={{ fontSize: '1.6rem', fontWeight: '700', color: '#111827', margin: 0 }}>
+              管理ダッシュボード
+            </h1>
+            <p style={{ color: '#6b7280', marginTop: '0.25rem', fontSize: '0.9rem' }}>
+              ようこそ、{user?.name} さん
+            </p>
+          </div>
           <button
             onClick={handleLogout}
             style={{
               padding: '0.5rem 1rem',
               border: '1px solid #dc2626',
               borderRadius: '6px',
-              background: 'none',
+              backgroundColor: 'transparent',
               color: '#dc2626',
               cursor: 'pointer',
+              fontSize: '0.875rem',
             }}
           >
             ログアウト
           </button>
         </div>
-      </div>
-      <p style={{ color: '#666' }}>管理ダッシュボードは後続のPBIで実装予定です。</p>
+
+        {/* クイックアクション */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: '1rem' }}>
+          {/* 著者管理カード */}
+          <Link
+            href="/admin/authors"
+            style={{ textDecoration: 'none' }}
+          >
+            <div
+              style={{
+                backgroundColor: '#fff',
+                border: '1px solid #e5e7eb',
+                borderRadius: '12px',
+                padding: '1.5rem',
+                cursor: 'pointer',
+                transition: 'box-shadow 0.2s',
+              }}
+            >
+              <div style={{ fontSize: '2rem', marginBottom: '0.75rem' }}>👤</div>
+              <h3 style={{ fontSize: '1rem', fontWeight: '700', color: '#111827', marginBottom: '0.5rem' }}>
+                著者管理
+              </h3>
+              <p style={{ fontSize: '0.85rem', color: '#6b7280', margin: 0 }}>
+                著者アカウントの作成・編集・無効化
+              </p>
+            </div>
+          </Link>
+        </div>
+      </main>
     </div>
   );
 }

--- a/output_system/frontend/src/components/layout/Sidebar.tsx
+++ b/output_system/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,140 @@
+/**
+ * @file Sidebar.tsx
+ * @description 管理者向けサイドバーナビゲーションコンポーネント
+ *
+ * 管理者ダッシュボード・著者管理などの管理機能へのナビゲーションリンクを提供する。
+ * 現在のパスに基づいてアクティブなメニュー項目をハイライトする。
+ *
+ * 使用箇所:
+ * - 管理者向け各ページのレイアウト
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+/**
+ * サイドバーのメニュー項目型定義
+ */
+interface NavItem {
+  /** メニューラベル */
+  label: string;
+  /** リンク先パス */
+  href: string;
+  /** アイコン文字（絵文字） */
+  icon: string;
+}
+
+/** 管理者向けナビゲーション項目 */
+const NAV_ITEMS: NavItem[] = [
+  {
+    label: 'ダッシュボード',
+    href: '/admin/dashboard',
+    icon: '🏠',
+  },
+  {
+    label: '著者管理',
+    href: '/admin/authors',
+    icon: '👤',
+  },
+];
+
+/**
+ * 管理者向けサイドバーコンポーネント
+ *
+ * @returns サイドバーナビゲーション JSX 要素
+ */
+export default function Sidebar() {
+  // 現在のパスを取得してアクティブ状態の判定に使用する
+  const pathname = usePathname();
+
+  return (
+    <aside
+      style={{
+        width: '240px',
+        minHeight: '100vh',
+        backgroundColor: '#1e293b',
+        color: '#f1f5f9',
+        display: 'flex',
+        flexDirection: 'column',
+        flexShrink: 0,
+      }}
+    >
+      {/* サイドバーヘッダー */}
+      <div
+        style={{
+          padding: '1.5rem 1rem',
+          borderBottom: '1px solid #334155',
+          marginBottom: '0.5rem',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '1.1rem',
+            fontWeight: '700',
+            color: '#f1f5f9',
+            letterSpacing: '0.05em',
+          }}
+        >
+          📚 Signia
+        </div>
+        <div
+          style={{
+            fontSize: '0.75rem',
+            color: '#94a3b8',
+            marginTop: '0.25rem',
+          }}
+        >
+          管理者コンソール
+        </div>
+      </div>
+
+      {/* ナビゲーションリスト */}
+      <nav style={{ padding: '0 0.5rem', flex: 1 }}>
+        {NAV_ITEMS.map((item) => {
+          // パスが一致する場合またはサブパスの場合はアクティブとみなす
+          const isActive =
+            pathname === item.href || pathname.startsWith(item.href + '/');
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.75rem',
+                padding: '0.625rem 0.75rem',
+                borderRadius: '6px',
+                marginBottom: '0.25rem',
+                textDecoration: 'none',
+                color: isActive ? '#f1f5f9' : '#94a3b8',
+                backgroundColor: isActive ? '#2563eb' : 'transparent',
+                fontWeight: isActive ? '600' : '400',
+                fontSize: '0.9rem',
+                transition: 'background-color 0.15s, color 0.15s',
+              }}
+            >
+              <span style={{ fontSize: '1rem' }}>{item.icon}</span>
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* サイドバーフッター（バージョン情報等） */}
+      <div
+        style={{
+          padding: '1rem',
+          borderTop: '1px solid #334155',
+          fontSize: '0.75rem',
+          color: '#475569',
+          textAlign: 'center',
+        }}
+      >
+        Signia Admin v1.0
+      </div>
+    </aside>
+  );
+}

--- a/output_system/frontend/src/lib/api.ts
+++ b/output_system/frontend/src/lib/api.ts
@@ -601,3 +601,122 @@ export interface BookReadUrlResult {
 export async function apiGetBookReadUrl(bookId: string): Promise<BookReadUrlResult> {
   return apiRequest(`/fan/books/${bookId}/read`);
 }
+
+// ===== 管理者向け著者管理API =====
+
+/**
+ * 著者情報型定義（管理者向け）
+ * バックエンドの AuthorInfo 型に対応する
+ */
+export interface AuthorInfo {
+  /** ユーザー ID（UUID） */
+  id: string;
+  /** メールアドレス */
+  email: string;
+  /** 表示名 */
+  name: string;
+  /** ロール（常に 'author'） */
+  role: 'author';
+  /** アカウント有効フラグ */
+  isActive: boolean;
+  /** 作成日時（ISO 8601形式） */
+  createdAt: string;
+  /** 更新日時（ISO 8601形式） */
+  updatedAt: string;
+}
+
+/**
+ * 著者の登録書籍情報型定義
+ */
+export interface AuthorBook {
+  /** 書籍 ID */
+  id: string;
+  /** 書籍タイトル */
+  title: string;
+  /** 書籍ステータス */
+  status: 'draft' | 'published' | 'archived';
+  /** ファイル形式 */
+  format: string | null;
+  /** 作成日時（ISO 8601形式） */
+  createdAt: string;
+}
+
+/**
+ * 著者詳細型定義（登録書籍一覧含む）
+ */
+export interface AuthorDetail extends AuthorInfo {
+  /** 著者が登録した書籍の一覧 */
+  books: AuthorBook[];
+}
+
+/**
+ * 著者一覧を取得する（admin ロール専用）
+ *
+ * @returns 著者の配列と件数
+ * @throws {ApiError} 認証・認可エラー時
+ */
+export async function apiGetAuthors(): Promise<{ authors: AuthorInfo[]; count: number }> {
+  return apiRequest('/admin/authors');
+}
+
+/**
+ * 著者アカウントを作成する（admin ロール専用）
+ *
+ * @param email - メールアドレス
+ * @param name - 表示名
+ * @param password - 初期パスワード
+ * @returns 作成した著者情報
+ * @throws {ApiError} バリデーションエラー・メール重複時など
+ */
+export async function apiCreateAuthor(
+  email: string,
+  name: string,
+  password: string
+): Promise<{ author: AuthorInfo }> {
+  return apiRequest('/admin/authors', {
+    method: 'POST',
+    body: { email, name, password },
+  });
+}
+
+/**
+ * 著者詳細を取得する（admin ロール専用）
+ *
+ * @param authorId - 著者 ID（UUID）
+ * @returns 著者詳細情報（登録書籍一覧含む）
+ * @throws {ApiError} 著者が見つからない場合など
+ */
+export async function apiGetAuthor(authorId: string): Promise<{ author: AuthorDetail }> {
+  return apiRequest(`/admin/authors/${authorId}`);
+}
+
+/**
+ * 著者情報を更新する（admin ロール専用）
+ *
+ * @param authorId - 著者 ID（UUID）
+ * @param data - 更新データ（name, email, isActive）
+ * @returns 更新後の著者情報
+ * @throws {ApiError} バリデーションエラー・メール重複時など
+ */
+export async function apiUpdateAuthor(
+  authorId: string,
+  data: { name?: string; email?: string; isActive?: boolean }
+): Promise<{ author: AuthorInfo }> {
+  return apiRequest(`/admin/authors/${authorId}`, {
+    method: 'PUT',
+    body: data,
+  });
+}
+
+/**
+ * 著者アカウントを無効化する（admin ロール専用、論理削除）
+ *
+ * @param authorId - 著者 ID（UUID）
+ * @returns 無効化後の著者情報
+ * @throws {ApiError} 著者が見つからない場合など
+ */
+export async function apiDeactivateAuthor(authorId: string): Promise<{ author: AuthorInfo; message: string }> {
+  return apiRequest(`/admin/authors/${authorId}`, {
+    method: 'DELETE',
+  });
+}


### PR DESCRIPTION
## Summary

システム管理者が管理画面から著者アカウントの作成・編集・無効化を行えるようにした。
著者一覧画面と著者詳細画面が利用可能になり、著者を効率的に管理できる。

### 実装内容

**対象PBI**: #16 PBI 5.1: 管理者が著者アカウントを作成・管理できる

- #45 Task 5.1.1: 著者管理APIを実装する ✅
- #46 Task 5.1.2: 著者管理画面（一覧・詳細・作成）を作成する ✅

### 変更ファイル

**バックエンド**
- `output_system/backend/src/services/admin.service.ts` - 著者CRUD操作ビジネスロジック
- `output_system/backend/src/controllers/admin.controller.ts` - HTTPリクエスト処理
- `output_system/backend/src/routes/admin.routes.ts` - adminOnlyミドルウェアでRBACチェック
- `output_system/backend/src/routes/index.ts` - /api/adminルート追加
- `output_system/backend/src/utils/errors.ts` - ConflictError (409) 追加
- `output_system/backend/test/services/admin.service.test.ts` - サービスユニットテスト15件
- `output_system/backend/test/controllers/admin.controller.test.ts` - コントローラーユニットテスト10件

**フロントエンド**
- `output_system/frontend/src/lib/api.ts` - 著者管理API関数追加（apiGetAuthors等）
- `output_system/frontend/src/components/layout/Sidebar.tsx` - 管理者サイドバーナビゲーション
- `output_system/frontend/src/app/admin/authors/page.tsx` - 著者一覧画面
- `output_system/frontend/src/app/admin/authors/new/page.tsx` - 著者作成フォーム
- `output_system/frontend/src/app/admin/authors/[authorId]/page.tsx` - 著者詳細・編集画面
- `output_system/frontend/src/app/admin/dashboard/page.tsx` - ダッシュボード更新

## Test Plan

- [x] POST /api/admin/authors で著者アカウントが作成される
- [x] GET /api/admin/authors で著者一覧が返る
- [x] GET /api/admin/authors/:id で著者詳細が返る（登録書籍一覧含む）
- [x] PUT /api/admin/authors/:id で著者情報が更新される
- [x] DELETE /api/admin/authors/:id で著者が無効化される
- [x] admin以外のロールは403が返る
- [x] 著者一覧画面にテーブル形式で著者が表示される
- [x] 新規著者を作成できる（フォームバリデーション付き）
- [x] 著者詳細画面で著者情報と登録書籍一覧が表示される
- [x] 著者情報を編集できる（インライン編集フォーム）
- [x] 著者を無効化できる（確認ダイアログ付き）
- [x] サイドバーナビゲーションが動作する
- [x] ユニットテスト25件パス（全156件パス）

## Screenshots

| 画面名 | スクリーンショット |
|--------|-------------------|
| 著者一覧 | ![著者一覧](https://github.com/okegawaatclink/gaido-signia/raw/60f8976c58416016f0a2531a8bf5d5eb19e6de1f/ai_generated/screenshots/task-46_authors-list.png) |
| 著者作成フォーム | ![著者作成](https://github.com/okegawaatclink/gaido-signia/raw/60f8976c58416016f0a2531a8bf5d5eb19e6de1f/ai_generated/screenshots/task-46_author-new.png) |
| 著者詳細 | ![著者詳細](https://github.com/okegawaatclink/gaido-signia/raw/60f8976c58416016f0a2531a8bf5d5eb19e6de1f/ai_generated/screenshots/task-46_author-detail.png) |

## Related Issues

- Closes #16

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)