### PR TITLE
[PBI 5.2: 外部システムがAPIで書籍アクセス権を付与・サインを登録できる] 実装完了

### DIFF
--- a/output_system/backend/src/controllers/api-key.controller.ts
+++ b/output_system/backend/src/controllers/api-key.controller.ts
@@ -1,0 +1,175 @@
+/**
+ * @file api-key.controller.ts
+ * @description API Key管理コントローラー
+ *
+ * Admin向けAPIキー管理エンドポイントのHTTPリクエスト処理を担当する。
+ * リクエストバリデーション、サービス呼び出し、レスポンス整形を行う。
+ *
+ * エンドポイント:
+ * - GET    /api/admin/api-keys       : APIキー一覧取得
+ * - POST   /api/admin/api-keys       : APIキー発行
+ * - GET    /api/admin/api-keys/:id   : APIキー詳細取得
+ * - DELETE /api/admin/api-keys/:id   : APIキー無効化
+ *
+ * 認証・認可:
+ * - 全エンドポイントに JWT 認証が必要（authenticate）
+ * - admin ロールのみアクセス可能（adminOnly）
+ *
+ * セキュリティ注意事項:
+ * - APIキーの平文は POST レスポンスで一度だけ返す
+ * - 以降のレスポンスにはハッシュも平文も含まない
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { validationResult } from 'express-validator';
+import { apiKeyService } from '../services/api-key.service';
+import { ValidationError } from '../utils/errors';
+import { logger } from '../utils/logger';
+
+/**
+ * GET /api/admin/api-keys
+ * APIキー一覧を取得する
+ *
+ * レスポンス (200):
+ * - apiKeys: APIキー情報の配列（key_hashは含まない）
+ * - count: APIキー数
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function listApiKeys(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    logger.info('GET /api/admin/api-keys called', { adminId: req.user?.userId });
+
+    const apiKeys = await apiKeyService.listApiKeys();
+
+    res.status(200).json({
+      apiKeys,
+      count: apiKeys.length,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * POST /api/admin/api-keys
+ * 新しいAPIキーを発行する
+ *
+ * リクエスト (application/json):
+ * - name: キー名（必須、1〜100文字）
+ * - description: 説明（オプション）
+ * - permissions: 許可する操作リスト（オプション、デフォルト: 全操作許可）
+ * - expiresAt: 有効期限（オプション、省略時は無期限）
+ *
+ * レスポンス (201):
+ * - apiKey: 作成したAPIキー情報
+ * - plainKey: 平文のAPIキー（この一度だけ返される）
+ *
+ * 重要: plainKey はこのレスポンスでのみ取得可能。
+ * サーバー側は平文を保存しないため、紛失した場合は再発行が必要。
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function createApiKey(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    logger.info('POST /api/admin/api-keys called', { adminId: req.user?.userId });
+
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const { name, description, permissions, expiresAt } = req.body;
+
+    const result = await apiKeyService.createApiKey({
+      name,
+      description,
+      permissions,
+      expiresAt: expiresAt ? new Date(expiresAt) : undefined,
+    });
+
+    // 201 Created でAPIキー情報と平文キーを返す
+    // 平文キー（plainKey）はこのレスポンスで一度のみ提供される
+    res.status(201).json({
+      apiKey: result.apiKey,
+      plainKey: result.plainKey,
+      message:
+        'APIキーが発行されました。この画面のplainKeyは再表示できません。安全な場所に保管してください。',
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * GET /api/admin/api-keys/:id
+ * 指定IDのAPIキー詳細を取得する
+ *
+ * レスポンス (200):
+ * - apiKey: APIキー情報（key_hashは含まない）
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function getApiKey(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    logger.info('GET /api/admin/api-keys/:id called', {
+      adminId: req.user?.userId,
+      keyId: req.params.id,
+    });
+
+    const apiKey = await apiKeyService.getApiKey(req.params.id);
+
+    res.status(200).json({ apiKey });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * DELETE /api/admin/api-keys/:id
+ * APIキーを無効化する（論理削除）
+ *
+ * is_active = false に設定してAPIキーを使用不可にする。
+ * レコード自体は保持するため、監査ログとの紐付けが可能。
+ *
+ * レスポンス (200):
+ * - apiKey: 無効化後のAPIキー情報
+ * - message: 完了メッセージ
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function deactivateApiKey(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    logger.info('DELETE /api/admin/api-keys/:id called', {
+      adminId: req.user?.userId,
+      keyId: req.params.id,
+    });
+
+    const apiKey = await apiKeyService.deactivateApiKey(req.params.id);
+
+    res.status(200).json({
+      apiKey,
+      message: 'APIキーを無効化しました',
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/output_system/backend/src/controllers/external.controller.ts
+++ b/output_system/backend/src/controllers/external.controller.ts
@@ -1,0 +1,353 @@
+/**
+ * @file external.controller.ts
+ * @description 外部連携APIコントローラー
+ *
+ * 外部購入システムからのAPI呼び出しを処理するコントローラー。
+ * リクエストバリデーション、サービス呼び出し、監査ログ記録、レスポンス整形を行う。
+ *
+ * エンドポイント:
+ * - POST   /api/external/book-access     : 書籍アクセス権付与
+ * - DELETE /api/external/book-access/:id : アクセス権削除
+ * - GET    /api/external/book-access     : アクセス権一覧取得
+ * - POST   /api/external/signs           : サインデータ登録
+ * - GET    /api/external/signs/:id       : サインデータ取得
+ *
+ * 認証・認可:
+ * - 全エンドポイントに API Key 認証が必要（authenticateApiKey）
+ * - レート制限適用（externalApiRateLimit）
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { validationResult } from 'express-validator';
+import { externalService } from '../services/external.service';
+import { ValidationError } from '../utils/errors';
+import { recordAuditLog, getClientIpAddress } from '../middleware/audit.middleware';
+import { logger } from '../utils/logger';
+
+/**
+ * POST /api/external/book-access
+ * ファンに書籍アクセス権を付与する
+ *
+ * リクエスト (application/json):
+ * - bookId: 書籍ID（必須、UUID形式）
+ * - fanEmail: ファンのメールアドレス（必須）
+ * - externalReference: 外部システムの参照ID（オプション）
+ *
+ * レスポンス (201):
+ * - 作成されたアクセス権情報
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function grantBookAccess(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    logger.info('POST /api/external/book-access called', {
+      apiKeyId: req.apiKey?.id,
+      apiKeyName: req.apiKey?.name,
+    });
+
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const { bookId, fanEmail, externalReference } = req.body;
+
+    const accessRecord = await externalService.grantBookAccess({
+      bookId,
+      fanEmail,
+      externalReference,
+    });
+
+    // 監査ログ記録（外部APIによる書籍アクセス権付与）
+    await recordAuditLog({
+      userId: null, // 外部API呼び出しはユーザーIDなし
+      action: 'external_book_access_grant',
+      resourceType: 'book_access',
+      resourceId: accessRecord.id,
+      details: {
+        apiKeyId: req.apiKey?.id,
+        apiKeyName: req.apiKey?.name,
+        bookId,
+        fanEmail,
+        externalReference,
+      },
+      result: 'success',
+      ipAddress: getClientIpAddress(req),
+      userAgent: req.headers['user-agent'],
+    });
+
+    res.status(201).json(accessRecord);
+  } catch (error) {
+    // 失敗時も監査ログを記録
+    await recordAuditLog({
+      userId: null,
+      action: 'external_book_access_grant',
+      resourceType: 'book_access',
+      details: {
+        apiKeyId: req.apiKey?.id,
+        bookId: req.body?.bookId,
+        fanEmail: req.body?.fanEmail,
+        error: (error as Error).message,
+      },
+      result: 'failed',
+      ipAddress: getClientIpAddress(req),
+      userAgent: req.headers['user-agent'],
+    });
+    next(error);
+  }
+}
+
+/**
+ * DELETE /api/external/book-access/:id
+ * 書籍アクセス権を削除する
+ *
+ * レスポンス (200):
+ * - message: 完了メッセージ
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function deleteBookAccess(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    logger.info('DELETE /api/external/book-access/:id called', {
+      apiKeyId: req.apiKey?.id,
+      accessId: req.params.id,
+    });
+
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    await externalService.deleteBookAccess(req.params.id);
+
+    // 監査ログ記録（外部APIによる書籍アクセス権削除）
+    await recordAuditLog({
+      userId: null,
+      action: 'external_book_access_delete',
+      resourceType: 'book_access',
+      resourceId: req.params.id,
+      details: {
+        apiKeyId: req.apiKey?.id,
+        apiKeyName: req.apiKey?.name,
+      },
+      result: 'success',
+      ipAddress: getClientIpAddress(req),
+      userAgent: req.headers['user-agent'],
+    });
+
+    res.status(200).json({ message: '書籍アクセス権を削除しました' });
+  } catch (error) {
+    await recordAuditLog({
+      userId: null,
+      action: 'external_book_access_delete',
+      resourceType: 'book_access',
+      resourceId: req.params.id,
+      details: {
+        apiKeyId: req.apiKey?.id,
+        error: (error as Error).message,
+      },
+      result: 'failed',
+      ipAddress: getClientIpAddress(req),
+      userAgent: req.headers['user-agent'],
+    });
+    next(error);
+  }
+}
+
+/**
+ * GET /api/external/book-access
+ * 書籍アクセス権一覧を取得する
+ *
+ * クエリパラメータ（すべてオプション）:
+ * - bookId: 書籍IDでフィルタ
+ * - fanId: ファンIDでフィルタ
+ * - externalReference: 外部参照IDでフィルタ
+ *
+ * レスポンス (200):
+ * - アクセス権レコードの配列と件数
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function listBookAccess(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    logger.info('GET /api/external/book-access called', {
+      apiKeyId: req.apiKey?.id,
+      query: req.query,
+    });
+
+    const { bookId, fanId, externalReference } = req.query as {
+      bookId?: string;
+      fanId?: string;
+      externalReference?: string;
+    };
+
+    const accessList = await externalService.listBookAccess({
+      bookId,
+      fanId,
+      externalReference,
+    });
+
+    res.status(200).json({
+      bookAccess: accessList,
+      count: accessList.length,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * POST /api/external/signs
+ * サインデータを登録する
+ *
+ * リクエスト (application/json):
+ * - authorId: 著者ID（必須、UUID形式）
+ * - name: サイン名（必須）
+ * - type: サイン種別（必須: common / individual）
+ * - imageBase64: Base64エンコードされたPNG画像（必須）
+ *
+ * レスポンス (201):
+ * - 作成されたサインデータ
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function createExternalSign(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    logger.info('POST /api/external/signs called', {
+      apiKeyId: req.apiKey?.id,
+      authorId: req.body?.authorId,
+    });
+
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const { authorId, name, type, imageBase64 } = req.body;
+
+    const signRecord = await externalService.createExternalSign({
+      authorId,
+      name,
+      type,
+      imageBase64,
+    });
+
+    // 監査ログ記録（外部APIによるサインデータ登録）
+    await recordAuditLog({
+      userId: null,
+      action: 'external_sign_create',
+      resourceType: 'sign',
+      resourceId: signRecord.id,
+      details: {
+        apiKeyId: req.apiKey?.id,
+        apiKeyName: req.apiKey?.name,
+        authorId,
+        signName: name,
+        signType: type,
+      },
+      result: 'success',
+      ipAddress: getClientIpAddress(req),
+      userAgent: req.headers['user-agent'],
+    });
+
+    res.status(201).json(signRecord);
+  } catch (error) {
+    await recordAuditLog({
+      userId: null,
+      action: 'external_sign_create',
+      resourceType: 'sign',
+      details: {
+        apiKeyId: req.apiKey?.id,
+        authorId: req.body?.authorId,
+        error: (error as Error).message,
+      },
+      result: 'failed',
+      ipAddress: getClientIpAddress(req),
+      userAgent: req.headers['user-agent'],
+    });
+    next(error);
+  }
+}
+
+/**
+ * GET /api/external/signs/:id
+ * サインデータを取得する
+ *
+ * レスポンス (200):
+ * - サインデータ（署名付き画像URLを含む）
+ *
+ * @param req - Express リクエストオブジェクト
+ * @param res - Express レスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ */
+export async function getExternalSign(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    logger.info('GET /api/external/signs/:id called', {
+      apiKeyId: req.apiKey?.id,
+      signId: req.params.id,
+    });
+
+    // バリデーションエラーチェック
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      throw new ValidationError(
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(', ')
+      );
+    }
+
+    const signRecord = await externalService.getExternalSign(req.params.id);
+
+    res.status(200).json(signRecord);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/output_system/backend/src/middleware/api-key.middleware.ts
+++ b/output_system/backend/src/middleware/api-key.middleware.ts
@@ -1,0 +1,162 @@
+/**
+ * @file api-key.middleware.ts
+ * @description API Key認証ミドルウェア
+ *
+ * 外部システム連携API用のAPI Key認証を提供する。
+ * X-API-Keyヘッダーから取得したキーをSHA-256でハッシュ化し、
+ * api_keysテーブルのkey_hashと照合して認証を行う。
+ *
+ * セキュリティ設計:
+ * - APIキーは平文をDBに保存しない（SHA-256ハッシュのみ保存）
+ * - 無効化されたキー（is_active = false）はアクセス拒否
+ * - 有効期限切れのキーはアクセス拒否
+ * - 最終使用日時を非同期で更新してパフォーマンスを維持
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+import { db } from '../config/database';
+import { UnauthorizedError } from '../utils/errors';
+import { logger } from '../utils/logger';
+
+/**
+ * API Key情報の型定義
+ * api_keysテーブルから取得したレコードを表す
+ */
+export interface ApiKeyInfo {
+  /** APIキーID */
+  id: string;
+  /** キー名（管理用） */
+  name: string;
+  /** 許可されたAPI操作のリスト */
+  permissions: string[];
+  /** 有効フラグ */
+  isActive: boolean;
+  /** 有効期限（nullは無期限） */
+  expiresAt: Date | null;
+}
+
+/**
+ * Express RequestオブジェクトへのAPI Key情報プロパティのType拡張
+ * API Key認証後のリクエストでreq.apiKeyにアクセス可能にする
+ */
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      /** 認証済みAPI Key情報（API Key検証後にセットされる） */
+      apiKey?: ApiKeyInfo;
+    }
+  }
+}
+
+/**
+ * API KeyをSHA-256でハッシュ化する
+ *
+ * @param apiKey - ハッシュ化するAPI Key文字列
+ * @returns SHA-256ハッシュ文字列（16進数）
+ */
+export function hashApiKey(apiKey: string): string {
+  return crypto.createHash('sha256').update(apiKey).digest('hex');
+}
+
+/**
+ * API Key認証ミドルウェア
+ *
+ * X-API-Keyヘッダーに有効なAPIキーが含まれている場合のみ処理を許可する。
+ * 認証成功時はreq.apiKeyにAPIキー情報をセットする。
+ *
+ * @param req - Expressリクエストオブジェクト
+ * @param res - Expressレスポンスオブジェクト
+ * @param next - 次のミドルウェア関数
+ *
+ * @example
+ * router.post('/book-access', authenticateApiKey, externalController.grantBookAccess);
+ */
+export async function authenticateApiKey(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    // X-API-KeyヘッダーからAPIキーを取得
+    const apiKey = req.headers['x-api-key'];
+
+    if (!apiKey || typeof apiKey !== 'string') {
+      throw new UnauthorizedError('X-API-Keyヘッダーが必要です');
+    }
+
+    // APIキーをSHA-256でハッシュ化してDBと照合
+    const keyHash = hashApiKey(apiKey);
+
+    const result = await db.query<{
+      id: string;
+      name: string;
+      permissions: string[];
+      is_active: boolean;
+      expires_at: Date | null;
+    }>(
+      `SELECT id, name, permissions, is_active, expires_at
+       FROM api_keys
+       WHERE key_hash = $1`,
+      [keyHash]
+    );
+
+    if (result.rows.length === 0) {
+      // キーが見つからない場合も「不正なAPIキー」として返す（情報漏洩防止）
+      logger.warn('API Key authentication failed: key not found', {
+        ip: req.socket?.remoteAddress,
+      });
+      throw new UnauthorizedError('不正なAPIキーです');
+    }
+
+    const keyRecord = result.rows[0];
+
+    // 無効化されたキーのチェック
+    if (!keyRecord.is_active) {
+      logger.warn('API Key authentication failed: key is inactive', {
+        keyId: keyRecord.id,
+        keyName: keyRecord.name,
+      });
+      throw new UnauthorizedError('このAPIキーは無効化されています');
+    }
+
+    // 有効期限チェック（expires_at が null の場合は無期限）
+    if (keyRecord.expires_at && new Date() > keyRecord.expires_at) {
+      logger.warn('API Key authentication failed: key is expired', {
+        keyId: keyRecord.id,
+        keyName: keyRecord.name,
+        expiresAt: keyRecord.expires_at,
+      });
+      throw new UnauthorizedError('このAPIキーは有効期限が切れています');
+    }
+
+    // req.apiKey に認証済みAPIキー情報をセット
+    req.apiKey = {
+      id: keyRecord.id,
+      name: keyRecord.name,
+      permissions: keyRecord.permissions || [],
+      isActive: keyRecord.is_active,
+      expiresAt: keyRecord.expires_at,
+    };
+
+    logger.debug('API Key authentication successful', {
+      keyId: keyRecord.id,
+      keyName: keyRecord.name,
+    });
+
+    // last_used_at を非同期で更新（認証フローをブロックしない）
+    db.query('UPDATE api_keys SET last_used_at = NOW() WHERE id = $1', [keyRecord.id]).catch(
+      (err) => {
+        logger.error('Failed to update api_key last_used_at', {
+          error: (err as Error).message,
+          keyId: keyRecord.id,
+        });
+      }
+    );
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/output_system/backend/src/middleware/audit.middleware.ts
+++ b/output_system/backend/src/middleware/audit.middleware.ts
@@ -20,18 +20,26 @@ import { logger } from '../utils/logger';
  * audit_logsテーブルのaction列に格納される値
  */
 export type AuditAction =
-  | 'login_success'  // ログイン成功
-  | 'login_failed'   // ログイン失敗（認証エラー）
-  | 'logout'         // ログアウト
-  | 'book_create'    // 書籍作成
-  | 'book_update'    // 書籍更新
-  | 'book_delete'    // 書籍削除
-  | 'sign_create'    // サイン作成
-  | 'sign_delete'    // サイン削除
-  | 'author_create'  // 著者アカウント作成
-  | 'author_update'  // 著者アカウント更新
-  | 'author_delete'  // 著者アカウント削除（無効化）
-  | 'compose_start'; // サイン合成開始
+  | 'login_success'           // ログイン成功
+  | 'login_failed'            // ログイン失敗（認証エラー）
+  | 'logout'                  // ログアウト
+  | 'book_create'             // 書籍作成
+  | 'book_update'             // 書籍更新
+  | 'book_delete'             // 書籍削除
+  | 'sign_create'             // サイン作成
+  | 'sign_delete'             // サイン削除
+  | 'author_create'           // 著者アカウント作成
+  | 'author_update'           // 著者アカウント更新
+  | 'author_delete'           // 著者アカウント削除（無効化）
+  | 'compose_start'           // サイン合成開始
+  // 外部連携API操作
+  | 'external_book_access_grant'   // 外部APIによる書籍アクセス権付与
+  | 'external_book_access_delete'  // 外部APIによる書籍アクセス権削除
+  | 'external_sign_create'         // 外部APIによるサインデータ登録
+  // APIキー管理操作
+  | 'api_key_create'          // APIキー発行
+  | 'api_key_deactivate'      // APIキー無効化
+  | 'api_key_delete';         // APIキー削除
 
 /**
  * 監査ログエントリーの型定義

--- a/output_system/backend/src/middleware/rate-limit.middleware.ts
+++ b/output_system/backend/src/middleware/rate-limit.middleware.ts
@@ -1,0 +1,127 @@
+/**
+ * @file rate-limit.middleware.ts
+ * @description レート制限ミドルウェア
+ *
+ * express-rate-limitを使用してAPIエンドポイントへのアクセス頻度を制限する。
+ * 外部連携APIにはAPI Key単位でのレート制限を適用する。
+ *
+ * 設計方針:
+ * - 外部連携API: 100 req/min/API Key
+ * - 一般API（JWT認証）: 200 req/min/IP
+ * - レート制限超過時: 429 Too Many Requests を返す
+ * - Retry-After ヘッダーを含めてクライアントに再試行タイミングを通知する
+ *
+ * 参考: https://github.com/express-rate-limit/express-rate-limit
+ */
+
+import rateLimit, { RateLimitRequestHandler } from 'express-rate-limit';
+import { Request, Response } from 'express';
+
+/**
+ * 外部連携API用レート制限ミドルウェア
+ *
+ * API Keyごとに 100 req/min のレート制限を適用する。
+ * authenticateApiKey ミドルウェアの後に適用することで、
+ * req.apiKey.id をキーとしてAPI Key単位でカウントする。
+ *
+ * authenticateApiKey の前に配置する場合は IPベースでカウントされる。
+ *
+ * @example
+ * router.use(externalApiRateLimit);
+ * router.use(authenticateApiKey);
+ */
+export const externalApiRateLimit: RateLimitRequestHandler = rateLimit({
+  // ウィンドウ期間: 1分（60,000ms）
+  windowMs: 60 * 1000,
+
+  // 1ウィンドウあたりの最大リクエスト数: 100 req/min
+  max: 100,
+
+  // レート制限のキー生成関数
+  // API Key認証後であればAPI Key IDをキーに、未認証の場合はIPアドレスをキーにする
+  keyGenerator: (req: Request): string => {
+    // req.apiKey は authenticateApiKey の後に設定される
+    // ルーターで authenticateApiKey → externalApiRateLimit の順に適用する場合は
+    // API Key IDをキーとして使用できる
+    if (req.apiKey?.id) {
+      return `api_key:${req.apiKey.id}`;
+    }
+    // フォールバック: IPアドレスをキーにする
+    const forwarded = req.headers['x-forwarded-for'];
+    if (forwarded) {
+      const ips = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+      return `ip:${ips.split(',')[0].trim()}`;
+    }
+    return `ip:${req.socket?.remoteAddress || 'unknown'}`;
+  },
+
+  // レート制限超過時のレスポンス
+  handler: (_req: Request, res: Response): void => {
+    res.status(429).json({
+      error: 'Too Many Requests',
+      message: 'レート制限を超過しました。しばらく経ってから再試行してください。',
+      statusCode: 429,
+    });
+  },
+
+  // 標準のRateLimitヘッダーを含める（RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset）
+  standardHeaders: true,
+
+  // 非推奨のX-RateLimit-*ヘッダーを無効化
+  legacyHeaders: false,
+
+  // レート制限メッセージ（handlerで上書きするため参照されない）
+  message: 'レート制限を超過しました。しばらく経ってから再試行してください。',
+});
+
+/**
+ * 一般API用レート制限ミドルウェア（IPアドレスベース）
+ *
+ * JWT認証APIに対して IP アドレスごとに 200 req/min のレート制限を適用する。
+ * ブルートフォース攻撃などの過剰アクセスを防ぐための基本的な保護。
+ */
+export const generalApiRateLimit: RateLimitRequestHandler = rateLimit({
+  // ウィンドウ期間: 1分（60,000ms）
+  windowMs: 60 * 1000,
+
+  // 1ウィンドウあたりの最大リクエスト数: 200 req/min
+  max: 200,
+
+  // レート制限超過時のレスポンス
+  handler: (_req: Request, res: Response): void => {
+    res.status(429).json({
+      error: 'Too Many Requests',
+      message: 'レート制限を超過しました。しばらく経ってから再試行してください。',
+      statusCode: 429,
+    });
+  },
+
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * 認証エンドポイント用レート制限ミドルウェア（ブルートフォース対策）
+ *
+ * ログインエンドポイントに対して IP アドレスごとに 10 req/min のレート制限を適用する。
+ * パスワードスプレー攻撃やブルートフォース攻撃への対策。
+ */
+export const authRateLimit: RateLimitRequestHandler = rateLimit({
+  // ウィンドウ期間: 1分（60,000ms）
+  windowMs: 60 * 1000,
+
+  // 1ウィンドウあたりの最大リクエスト数: 10 req/min（ログインは厳しく制限）
+  max: 10,
+
+  // レート制限超過時のレスポンス
+  handler: (_req: Request, res: Response): void => {
+    res.status(429).json({
+      error: 'Too Many Requests',
+      message: '認証試行回数が上限に達しました。しばらく経ってから再試行してください。',
+      statusCode: 429,
+    });
+  },
+
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/output_system/backend/src/routes/admin.routes.ts
+++ b/output_system/backend/src/routes/admin.routes.ts
@@ -28,6 +28,12 @@ import {
   updateAuthor,
   deactivateAuthor,
 } from '../controllers/admin.controller';
+import {
+  listApiKeys,
+  createApiKey,
+  getApiKey,
+  deactivateApiKey,
+} from '../controllers/api-key.controller';
 
 const router = Router();
 
@@ -141,6 +147,86 @@ router.delete(
   adminOnly,
   [param('id').isUUID().withMessage('著者 ID が不正です')],
   deactivateAuthor
+);
+
+// ======= API Key管理ルート =======
+
+/**
+ * GET /api/admin/api-keys
+ * APIキー一覧取得
+ * admin ロールのみアクセス可能
+ */
+router.get('/api-keys', authenticate, adminOnly, listApiKeys);
+
+/**
+ * POST /api/admin/api-keys
+ * 新しいAPIキーを発行する
+ *
+ * リクエストボディのバリデーション:
+ * - name: キー名（必須、1〜100文字）
+ * - description: 説明（オプション）
+ * - permissions: 許可する操作リスト（オプション）
+ * - expiresAt: 有効期限（オプション、ISO 8601形式）
+ *
+ * セキュリティ注意: plainKey はこのレスポンスで一度だけ返される
+ */
+router.post(
+  '/api-keys',
+  authenticate,
+  adminOnly,
+  [
+    // キー名は必須かつ 1〜100 文字
+    body('name')
+      .notEmpty()
+      .withMessage('キー名は必須です')
+      .isLength({ min: 1, max: 100 })
+      .withMessage('キー名は 1〜100 文字で入力してください')
+      .trim(),
+    // 説明はオプション
+    body('description').optional().isString().withMessage('説明は文字列で指定してください').trim(),
+    // permissions はオプションの文字列配列
+    body('permissions')
+      .optional()
+      .isArray()
+      .withMessage('permissions は配列で指定してください'),
+    body('permissions.*').optional().isString().withMessage('permissions の各要素は文字列で指定してください'),
+    // expiresAt はオプションの日時文字列（ISO 8601形式）
+    body('expiresAt')
+      .optional()
+      .isISO8601()
+      .withMessage('expiresAt は ISO 8601 形式（例: 2025-12-31T23:59:59Z）で指定してください'),
+  ],
+  createApiKey
+);
+
+/**
+ * GET /api/admin/api-keys/:id
+ * APIキー詳細取得
+ *
+ * パラメータバリデーション:
+ * - id: UUID 形式
+ */
+router.get(
+  '/api-keys/:id',
+  authenticate,
+  adminOnly,
+  [param('id').isUUID().withMessage('APIキー ID が不正です')],
+  getApiKey
+);
+
+/**
+ * DELETE /api/admin/api-keys/:id
+ * APIキーを無効化する（論理削除）
+ *
+ * パラメータバリデーション:
+ * - id: UUID 形式
+ */
+router.delete(
+  '/api-keys/:id',
+  authenticate,
+  adminOnly,
+  [param('id').isUUID().withMessage('APIキー ID が不正です')],
+  deactivateApiKey
 );
 
 export default router;

--- a/output_system/backend/src/routes/external.routes.ts
+++ b/output_system/backend/src/routes/external.routes.ts
@@ -1,0 +1,181 @@
+/**
+ * @file external.routes.ts
+ * @description 外部連携API ルーター
+ *
+ * 外部購入システムからのAPI呼び出しを処理するルーターを定義する。
+ * 全エンドポイントにAPI Key認証（X-API-Keyヘッダー）とレート制限が適用される。
+ *
+ * エンドポイント:
+ * - POST   /api/external/book-access     : ファンに書籍アクセス権を付与
+ * - DELETE /api/external/book-access/:id : アクセス権を削除
+ * - GET    /api/external/book-access     : アクセス権一覧取得
+ * - POST   /api/external/signs           : サインデータを登録
+ * - GET    /api/external/signs/:id       : サインデータを取得
+ *
+ * 認証フロー:
+ * 1. externalApiRateLimit: リクエスト頻度を制限（100 req/min/API Key）
+ * 2. authenticateApiKey: X-API-KeyヘッダーでAPI Key認証
+ *    → 認証後に req.apiKey に認証済みAPIキー情報がセットされる
+ *
+ * 注意: レート制限は authenticateApiKey の後に適用することで
+ *       API Key単位でカウントが行われる
+ */
+
+import { Router } from 'express';
+import { body, param, query } from 'express-validator';
+import { authenticateApiKey } from '../middleware/api-key.middleware';
+import { externalApiRateLimit } from '../middleware/rate-limit.middleware';
+import {
+  grantBookAccess,
+  deleteBookAccess,
+  listBookAccess,
+  createExternalSign,
+  getExternalSign,
+} from '../controllers/external.controller';
+
+const router = Router();
+
+// ルーター全体にAPI Key認証とレート制限を適用
+// 順序: API Key認証 → レート制限（API Key IDを使ってレート制限を適用するため）
+router.use(authenticateApiKey);
+router.use(externalApiRateLimit);
+
+// ======= 書籍アクセス権管理ルート =======
+
+/**
+ * POST /api/external/book-access
+ * ファンに書籍アクセス権を付与する
+ *
+ * リクエストボディのバリデーション:
+ * - bookId: UUID形式の書籍ID（必須）
+ * - fanEmail: 有効なメールアドレス（必須）
+ * - externalReference: 外部システム参照ID（オプション）
+ */
+router.post(
+  '/book-access',
+  [
+    // bookId は必須かつ UUID 形式
+    body('bookId')
+      .notEmpty()
+      .withMessage('bookId は必須です')
+      .isUUID()
+      .withMessage('bookId は UUID 形式で指定してください'),
+    // fanEmail は必須かつ有効なメールアドレス形式
+    body('fanEmail')
+      .notEmpty()
+      .withMessage('fanEmail は必須です')
+      .isEmail()
+      .withMessage('fanEmail は有効なメールアドレス形式で指定してください')
+      .normalizeEmail(),
+    // externalReference はオプション（外部システムの注文ID等）
+    body('externalReference')
+      .optional()
+      .isString()
+      .withMessage('externalReference は文字列で指定してください')
+      .isLength({ max: 255 })
+      .withMessage('externalReference は 255 文字以内で指定してください')
+      .trim(),
+  ],
+  grantBookAccess
+);
+
+/**
+ * DELETE /api/external/book-access/:id
+ * 指定IDの書籍アクセス権を削除する
+ *
+ * パラメータバリデーション:
+ * - id: UUID形式のアクセス権ID
+ */
+router.delete(
+  '/book-access/:id',
+  [param('id').isUUID().withMessage('アクセス権 ID は UUID 形式で指定してください')],
+  deleteBookAccess
+);
+
+/**
+ * GET /api/external/book-access
+ * 書籍アクセス権一覧を取得する（外部APIによる付与分のみ）
+ *
+ * クエリパラメータ（すべてオプション）:
+ * - bookId: 書籍IDでフィルタ（UUID形式）
+ * - fanId: ファンIDでフィルタ（UUID形式）
+ * - externalReference: 外部参照IDでフィルタ
+ */
+router.get(
+  '/book-access',
+  [
+    query('bookId')
+      .optional()
+      .isUUID()
+      .withMessage('bookId は UUID 形式で指定してください'),
+    query('fanId')
+      .optional()
+      .isUUID()
+      .withMessage('fanId は UUID 形式で指定してください'),
+    query('externalReference')
+      .optional()
+      .isString()
+      .withMessage('externalReference は文字列で指定してください')
+      .trim(),
+  ],
+  listBookAccess
+);
+
+// ======= サインデータ管理ルート =======
+
+/**
+ * POST /api/external/signs
+ * サインデータを登録する
+ *
+ * リクエストボディのバリデーション:
+ * - authorId: UUID形式の著者ID（必須）
+ * - name: サイン名（必須、1〜100文字）
+ * - type: サイン種別（必須: common / individual）
+ * - imageBase64: Base64エンコードされたPNG画像（必須）
+ */
+router.post(
+  '/signs',
+  [
+    // authorId は必須かつ UUID 形式
+    body('authorId')
+      .notEmpty()
+      .withMessage('authorId は必須です')
+      .isUUID()
+      .withMessage('authorId は UUID 形式で指定してください'),
+    // name は必須かつ 1〜100 文字
+    body('name')
+      .notEmpty()
+      .withMessage('name は必須です')
+      .isLength({ min: 1, max: 100 })
+      .withMessage('name は 1〜100 文字で指定してください')
+      .trim(),
+    // type は必須かつ common / individual のいずれか
+    body('type')
+      .notEmpty()
+      .withMessage('type は必須です')
+      .isIn(['common', 'individual'])
+      .withMessage('type は common または individual で指定してください'),
+    // imageBase64 は必須（サイズチェックはサービス層で実施）
+    body('imageBase64')
+      .notEmpty()
+      .withMessage('imageBase64 は必須です')
+      .isString()
+      .withMessage('imageBase64 は文字列で指定してください'),
+  ],
+  createExternalSign
+);
+
+/**
+ * GET /api/external/signs/:id
+ * 指定IDのサインデータを取得する
+ *
+ * パラメータバリデーション:
+ * - id: UUID形式のサインID
+ */
+router.get(
+  '/signs/:id',
+  [param('id').isUUID().withMessage('サイン ID は UUID 形式で指定してください')],
+  getExternalSign
+);
+
+export default router;

--- a/output_system/backend/src/routes/index.ts
+++ b/output_system/backend/src/routes/index.ts
@@ -13,6 +13,7 @@ import signsRouter from './signs.routes';
 import composeRouter from './compose.routes';
 import fanRouter from './fan.routes';
 import adminRouter from './admin.routes';
+import externalRouter from './external.routes';
 
 /**
  * メインAPIルーター
@@ -54,7 +55,7 @@ router.use('/fan', fanRouter);
 // 管理者向けAPIルーターをマウント（admin ロールのみアクセス可能）
 router.use('/admin', adminRouter);
 
-// TODO: 以下の各ルーターは後続のTaskで実装する
-// router.use('/external', externalRouter);
+// 外部連携APIルーターをマウント（API Key認証、外部購入システム向け）
+router.use('/external', externalRouter);
 
 export default router;

--- a/output_system/backend/src/services/api-key.service.ts
+++ b/output_system/backend/src/services/api-key.service.ts
@@ -1,0 +1,276 @@
+/**
+ * @file api-key.service.ts
+ * @description API Key管理サービス
+ *
+ * APIキーの発行・一覧取得・無効化・削除を担当するサービス層。
+ * データベース操作はここで行い、コントローラーはこのサービスを呼び出す。
+ *
+ * セキュリティ設計:
+ * - APIキーは生成時に一度だけ平文を返す
+ * - DBにはSHA-256ハッシュのみ保存（平文は永続化しない）
+ * - randomBytesで暗号的に安全なキーを生成（32バイト = 256ビット）
+ */
+
+import crypto from 'crypto';
+import { db } from '../config/database';
+import { hashApiKey } from '../middleware/api-key.middleware';
+import { NotFoundError } from '../utils/errors';
+import { logger } from '../utils/logger';
+
+/**
+ * API Key作成リクエストの型定義
+ */
+export interface CreateApiKeyRequest {
+  /** キー名（管理用の識別名） */
+  name: string;
+  /** 説明（使用目的・発行先等） */
+  description?: string;
+  /** 許可されたAPI操作のリスト */
+  permissions?: string[];
+  /** 有効期限（省略時は無期限） */
+  expiresAt?: Date;
+}
+
+/**
+ * API Key情報（一覧・詳細取得時に返すデータ）
+ * key_hashは返さない（セキュリティ上の理由）
+ */
+export interface ApiKeyRecord {
+  id: string;
+  name: string;
+  description: string | null;
+  permissions: string[];
+  isActive: boolean;
+  lastUsedAt: Date | null;
+  expiresAt: Date | null;
+  createdAt: Date;
+}
+
+/**
+ * API Key作成結果（発行時のみ平文キーを含む）
+ */
+export interface CreateApiKeyResult {
+  /** 作成したAPIキーの情報 */
+  apiKey: ApiKeyRecord;
+  /**
+   * 平文のAPIキー文字列
+   * 注意: この値はDBに保存されないため、この返却値が唯一の取得機会。
+   * 利用者はこの値を安全に保管すること。
+   */
+  plainKey: string;
+}
+
+/**
+ * APIキーを生成する
+ * cryptographically secure な乱数から64文字の16進文字列を生成する
+ *
+ * @returns 平文のAPIキー文字列（64文字の16進数）
+ */
+function generateApiKey(): string {
+  // 32バイト（256ビット）の乱数を生成して16進数文字列に変換
+  // これにより64文字のAPIキーが生成される
+  return crypto.randomBytes(32).toString('hex');
+}
+
+/**
+ * 新しいAPIキーを発行する
+ *
+ * @param request - APIキー作成リクエスト
+ * @returns 作成されたAPIキー情報と平文キー（一度だけ返される）
+ * @throws {ConflictError} 同名のAPIキーが既に存在する場合
+ */
+export async function createApiKey(request: CreateApiKeyRequest): Promise<CreateApiKeyResult> {
+  const { name, description, permissions = [], expiresAt } = request;
+
+  logger.info('Creating new API key', { name });
+
+  // 暗号的に安全なAPIキーを生成
+  const plainKey = generateApiKey();
+  // SHA-256でハッシュ化してDBに保存（平文は保存しない）
+  const keyHash = hashApiKey(plainKey);
+
+  const result = await db.query<{
+    id: string;
+    name: string;
+    description: string | null;
+    permissions: string[];
+    is_active: boolean;
+    last_used_at: Date | null;
+    expires_at: Date | null;
+    created_at: Date;
+  }>(
+    `INSERT INTO api_keys (key_hash, name, description, permissions, expires_at)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, name, description, permissions, is_active, last_used_at, expires_at, created_at`,
+    [keyHash, name, description || null, JSON.stringify(permissions), expiresAt || null]
+  );
+
+  const record = result.rows[0];
+
+  logger.info('API key created successfully', { keyId: record.id, name: record.name });
+
+  return {
+    apiKey: {
+      id: record.id,
+      name: record.name,
+      description: record.description,
+      permissions: record.permissions,
+      isActive: record.is_active,
+      lastUsedAt: record.last_used_at,
+      expiresAt: record.expires_at,
+      createdAt: record.created_at,
+    },
+    // 平文キーはこの返却時にのみ提供される
+    // 呼び出し側（コントローラー）がレスポンスとしてクライアントに返す
+    plainKey,
+  };
+}
+
+/**
+ * APIキー一覧を取得する
+ *
+ * @returns APIキー情報の配列（key_hashは含まない）
+ */
+export async function listApiKeys(): Promise<ApiKeyRecord[]> {
+  const result = await db.query<{
+    id: string;
+    name: string;
+    description: string | null;
+    permissions: string[];
+    is_active: boolean;
+    last_used_at: Date | null;
+    expires_at: Date | null;
+    created_at: Date;
+  }>(
+    `SELECT id, name, description, permissions, is_active, last_used_at, expires_at, created_at
+     FROM api_keys
+     ORDER BY created_at DESC`
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    permissions: row.permissions,
+    isActive: row.is_active,
+    lastUsedAt: row.last_used_at,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+  }));
+}
+
+/**
+ * 指定IDのAPIキーを取得する
+ *
+ * @param id - APIキーID（UUID）
+ * @returns APIキー情報
+ * @throws {NotFoundError} APIキーが見つからない場合
+ */
+export async function getApiKey(id: string): Promise<ApiKeyRecord> {
+  const result = await db.query<{
+    id: string;
+    name: string;
+    description: string | null;
+    permissions: string[];
+    is_active: boolean;
+    last_used_at: Date | null;
+    expires_at: Date | null;
+    created_at: Date;
+  }>(
+    `SELECT id, name, description, permissions, is_active, last_used_at, expires_at, created_at
+     FROM api_keys
+     WHERE id = $1`,
+    [id]
+  );
+
+  if (result.rows.length === 0) {
+    throw new NotFoundError(`APIキーが見つかりません: ${id}`);
+  }
+
+  const row = result.rows[0];
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    permissions: row.permissions,
+    isActive: row.is_active,
+    lastUsedAt: row.last_used_at,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * APIキーを無効化する（論理削除）
+ *
+ * is_active = false に設定することで、キーを使用不可にする。
+ * キーのレコード自体は保持するため、監査ログとの連携が可能。
+ *
+ * @param id - 無効化するAPIキーID（UUID）
+ * @throws {NotFoundError} APIキーが見つからない場合
+ */
+export async function deactivateApiKey(id: string): Promise<ApiKeyRecord> {
+  const result = await db.query<{
+    id: string;
+    name: string;
+    description: string | null;
+    permissions: string[];
+    is_active: boolean;
+    last_used_at: Date | null;
+    expires_at: Date | null;
+    created_at: Date;
+  }>(
+    `UPDATE api_keys
+     SET is_active = false
+     WHERE id = $1
+     RETURNING id, name, description, permissions, is_active, last_used_at, expires_at, created_at`,
+    [id]
+  );
+
+  if (result.rows.length === 0) {
+    throw new NotFoundError(`APIキーが見つかりません: ${id}`);
+  }
+
+  const row = result.rows[0];
+  logger.info('API key deactivated', { keyId: row.id, name: row.name });
+
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    permissions: row.permissions,
+    isActive: row.is_active,
+    lastUsedAt: row.last_used_at,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * APIキーを削除する（物理削除）
+ *
+ * 論理削除（deactivate）と異なり、レコードを完全に削除する。
+ * 通常は deactivateApiKey を使用することを推奨。
+ * 誤って発行したキーの完全削除時に使用する。
+ *
+ * @param id - 削除するAPIキーID（UUID）
+ * @throws {NotFoundError} APIキーが見つからない場合
+ */
+export async function deleteApiKey(id: string): Promise<void> {
+  const result = await db.query('DELETE FROM api_keys WHERE id = $1 RETURNING id, name', [id]);
+
+  if (result.rows.length === 0) {
+    throw new NotFoundError(`APIキーが見つかりません: ${id}`);
+  }
+
+  logger.info('API key deleted', { keyId: result.rows[0].id, name: result.rows[0].name });
+}
+
+/** api-key.service をオブジェクト形式でもエクスポート（他ファイルからの利用を容易にする） */
+export const apiKeyService = {
+  createApiKey,
+  listApiKeys,
+  getApiKey,
+  deactivateApiKey,
+  deleteApiKey,
+};

--- a/output_system/backend/src/services/external.service.ts
+++ b/output_system/backend/src/services/external.service.ts
@@ -1,0 +1,457 @@
+/**
+ * @file external.service.ts
+ * @description 外部連携APIサービス
+ *
+ * 外部購入システムからAPI経由で呼び出される機能のビジネスロジックを提供する。
+ * - 書籍アクセス権の付与・削除・一覧取得
+ * - サインデータの登録・取得
+ *
+ * セキュリティ設計:
+ * - ファンが存在しない場合は仮登録（fan ロール）を行う
+ * - Base64画像のサイズ上限チェック（5MB相当）
+ * - 外部参照IDはexternalReferenceとして保存（冪等性確保に活用可能）
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { db } from '../config/database';
+import { storageService } from './storage.service';
+import { NotFoundError, ValidationError } from '../utils/errors';
+import { logger } from '../utils/logger';
+
+/**
+ * Base64画像の最大サイズ（バイト換算）
+ * Base64エンコードは元データの約4/3倍のサイズになるため、
+ * 5MBのBase64文字列 ≒ 3.75MBの実データ
+ */
+const MAX_BASE64_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+
+// ===== 書籍アクセス権 型定義 =====
+
+/**
+ * 書籍アクセス権付与リクエスト
+ */
+export interface GrantBookAccessRequest {
+  /** 対象書籍ID（UUID） */
+  bookId: string;
+  /** ファンのメールアドレス（ユーザー検索・仮登録に使用） */
+  fanEmail: string;
+  /** 外部システムの注文ID等（オプション、重複防止・追跡用） */
+  externalReference?: string;
+}
+
+/**
+ * 書籍アクセス権レスポンス
+ */
+export interface BookAccessRecord {
+  id: string;
+  bookId: string;
+  fanId: string;
+  signedBookId: string | null;
+  grantedBy: string;
+  externalReference: string | null;
+  grantedAt: Date;
+  expiresAt: Date | null;
+}
+
+/**
+ * 書籍アクセス権一覧取得クエリパラメータ
+ */
+export interface ListBookAccessQuery {
+  /** 書籍IDでフィルタ（オプション） */
+  bookId?: string;
+  /** ファンIDでフィルタ（オプション） */
+  fanId?: string;
+  /** 外部参照IDでフィルタ（オプション） */
+  externalReference?: string;
+}
+
+// ===== サインデータ 型定義 =====
+
+/**
+ * 外部APIからのサイン登録リクエスト
+ */
+export interface ExternalCreateSignRequest {
+  /** 著者ID（UUID）: このサインを登録する著者 */
+  authorId: string;
+  /** サイン名（管理用ラベル） */
+  name: string;
+  /** サイン種別 */
+  type: 'common' | 'individual';
+  /** サイン画像（Base64エンコードされたPNG） */
+  imageBase64: string;
+}
+
+/**
+ * 外部APIサインレスポンス
+ */
+export interface ExternalSignRecord {
+  id: string;
+  authorId: string;
+  name: string;
+  type: string;
+  imageUrl: string | null;
+  isDefault: boolean;
+  createdAt: Date;
+}
+
+// ===== 書籍アクセス権 操作 =====
+
+/**
+ * ファンを検索し、存在しない場合は仮登録する
+ *
+ * 外部システムからのアクセス権付与時、ファンアカウントが未作成の場合は
+ * 仮登録（fan ロール、is_active = true）を行う。
+ * OAuth ログイン時に既存アカウントとマージされる。
+ *
+ * @param fanEmail - ファンのメールアドレス
+ * @returns ファンのユーザーID
+ */
+async function findOrCreateFanByEmail(fanEmail: string): Promise<string> {
+  // 既存ユーザーを検索
+  const existingUser = await db.query<{ id: string }>(
+    'SELECT id FROM users WHERE email = $1 AND role = $2',
+    [fanEmail, 'fan']
+  );
+
+  if (existingUser.rows.length > 0) {
+    logger.debug('Fan user found', { fanEmail, userId: existingUser.rows[0].id });
+    return existingUser.rows[0].id;
+  }
+
+  // 存在しない場合は仮登録（fan ロール）
+  // パスワードなし・OAuthなしの仮アカウント（OAuthログイン時にマージ）
+  const newUser = await db.query<{ id: string }>(
+    `INSERT INTO users (email, name, role, is_active)
+     VALUES ($1, $2, 'fan', true)
+     RETURNING id`,
+    [fanEmail, fanEmail.split('@')[0]] // 仮名はメールアドレスのローカルパートを使用
+  );
+
+  logger.info('Fan user provisionally registered', {
+    fanEmail,
+    userId: newUser.rows[0].id,
+  });
+
+  return newUser.rows[0].id;
+}
+
+/**
+ * 書籍アクセス権を付与する
+ *
+ * ファンのメールアドレスでユーザーを検索し、見つからない場合は仮登録する。
+ * 書籍が存在すること、同一のアクセス権が既に存在しないことを確認する。
+ *
+ * @param request - 書籍アクセス権付与リクエスト
+ * @returns 作成されたアクセス権レコード
+ * @throws {NotFoundError} 書籍が見つからない場合
+ */
+export async function grantBookAccess(request: GrantBookAccessRequest): Promise<BookAccessRecord> {
+  const { bookId, fanEmail, externalReference } = request;
+
+  logger.info('Granting book access', { bookId, fanEmail, externalReference });
+
+  // 書籍の存在確認（publishedまたはdraftのみ許可）
+  const bookResult = await db.query<{ id: string; status: string }>(
+    "SELECT id, status FROM books WHERE id = $1 AND status != 'archived'",
+    [bookId]
+  );
+
+  if (bookResult.rows.length === 0) {
+    throw new NotFoundError(`書籍が見つかりません: ${bookId}`);
+  }
+
+  // ファンを検索または仮登録
+  const fanId = await findOrCreateFanByEmail(fanEmail);
+
+  // アクセス権を作成
+  // 同一ユーザー・同一書籍のアクセス権が既存でも追加登録する（外部参照IDで管理）
+  const accessResult = await db.query<{
+    id: string;
+    book_id: string;
+    fan_id: string;
+    signed_book_id: string | null;
+    granted_by: string;
+    external_reference: string | null;
+    granted_at: Date;
+    expires_at: Date | null;
+  }>(
+    `INSERT INTO book_access (book_id, fan_id, granted_by, external_reference)
+     VALUES ($1, $2, 'api', $3)
+     RETURNING id, book_id, fan_id, signed_book_id, granted_by, external_reference, granted_at, expires_at`,
+    [bookId, fanId, externalReference || null]
+  );
+
+  const row = accessResult.rows[0];
+
+  logger.info('Book access granted', {
+    accessId: row.id,
+    bookId: row.book_id,
+    fanId: row.fan_id,
+    externalReference: row.external_reference,
+  });
+
+  return {
+    id: row.id,
+    bookId: row.book_id,
+    fanId: row.fan_id,
+    signedBookId: row.signed_book_id,
+    grantedBy: row.granted_by,
+    externalReference: row.external_reference,
+    grantedAt: row.granted_at,
+    expiresAt: row.expires_at,
+  };
+}
+
+/**
+ * 書籍アクセス権を削除する
+ *
+ * @param accessId - 削除するアクセス権ID（UUID）
+ * @throws {NotFoundError} アクセス権が見つからない場合
+ */
+export async function deleteBookAccess(accessId: string): Promise<void> {
+  const result = await db.query('DELETE FROM book_access WHERE id = $1 RETURNING id', [accessId]);
+
+  if (result.rows.length === 0) {
+    throw new NotFoundError(`アクセス権が見つかりません: ${accessId}`);
+  }
+
+  logger.info('Book access deleted', { accessId });
+}
+
+/**
+ * 書籍アクセス権一覧を取得する
+ *
+ * @param query - フィルタ条件（bookId, fanId, externalReference）
+ * @returns アクセス権レコードの配列
+ */
+export async function listBookAccess(query: ListBookAccessQuery): Promise<BookAccessRecord[]> {
+  // 動的クエリ構築（指定されたフィルタのみWHERE句に追加）
+  const conditions: string[] = ["ba.granted_by = 'api'"]; // 外部API付与のみ返す
+  const params: (string | undefined)[] = [];
+  let paramIndex = 1;
+
+  if (query.bookId) {
+    conditions.push(`ba.book_id = $${paramIndex++}`);
+    params.push(query.bookId);
+  }
+
+  if (query.fanId) {
+    conditions.push(`ba.fan_id = $${paramIndex++}`);
+    params.push(query.fanId);
+  }
+
+  if (query.externalReference) {
+    conditions.push(`ba.external_reference = $${paramIndex++}`);
+    params.push(query.externalReference);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const result = await db.query<{
+    id: string;
+    book_id: string;
+    fan_id: string;
+    signed_book_id: string | null;
+    granted_by: string;
+    external_reference: string | null;
+    granted_at: Date;
+    expires_at: Date | null;
+  }>(
+    `SELECT ba.id, ba.book_id, ba.fan_id, ba.signed_book_id, ba.granted_by,
+            ba.external_reference, ba.granted_at, ba.expires_at
+     FROM book_access ba
+     ${whereClause}
+     ORDER BY ba.granted_at DESC`,
+    params
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    bookId: row.book_id,
+    fanId: row.fan_id,
+    signedBookId: row.signed_book_id,
+    grantedBy: row.granted_by,
+    externalReference: row.external_reference,
+    grantedAt: row.granted_at,
+    expiresAt: row.expires_at,
+  }));
+}
+
+// ===== サインデータ 操作 =====
+
+/**
+ * Base64エンコードされた画像データを検証してBufferに変換する
+ *
+ * @param imageBase64 - Base64エンコードされた画像文字列（data URIスキーム付きも可）
+ * @returns PNG画像のBuffer
+ * @throws {ValidationError} 画像が大きすぎる場合または無効な形式の場合
+ */
+function decodeAndValidateBase64Image(imageBase64: string): Buffer {
+  // data URIスキーム（data:image/png;base64,）が付いている場合は除去
+  const base64Data = imageBase64.replace(/^data:image\/\w+;base64,/, '');
+
+  // サイズチェック（Base64文字列のサイズでチェック）
+  if (base64Data.length > MAX_BASE64_IMAGE_SIZE) {
+    throw new ValidationError(
+      `画像サイズが大きすぎます。Base64エンコード後のサイズは ${MAX_BASE64_IMAGE_SIZE / (1024 * 1024)}MB 以下にしてください`
+    );
+  }
+
+  // Base64デコード
+  const buffer = Buffer.from(base64Data, 'base64');
+
+  // PNGマジックナンバーの確認（89 50 4E 47 = \x89PNG）
+  if (
+    buffer.length < 8 ||
+    buffer[0] !== 0x89 ||
+    buffer[1] !== 0x50 ||
+    buffer[2] !== 0x4e ||
+    buffer[3] !== 0x47
+  ) {
+    throw new ValidationError('画像はPNG形式で提供してください');
+  }
+
+  return buffer;
+}
+
+/**
+ * 外部APIからサインデータを登録する
+ *
+ * Base64エンコードされたPNG画像をデコードしてS3に保存し、
+ * サインデータをDBに登録する。
+ *
+ * @param request - サイン登録リクエスト
+ * @returns 作成されたサインレコード
+ * @throws {NotFoundError} 著者が見つからない場合
+ * @throws {ValidationError} 画像が無効な場合
+ */
+export async function createExternalSign(
+  request: ExternalCreateSignRequest
+): Promise<ExternalSignRecord> {
+  const { authorId, name, type, imageBase64 } = request;
+
+  logger.info('Creating external sign', { authorId, name, type });
+
+  // 著者の存在確認
+  const authorResult = await db.query<{ id: string }>(
+    "SELECT id FROM users WHERE id = $1 AND role = 'author' AND is_active = true",
+    [authorId]
+  );
+
+  if (authorResult.rows.length === 0) {
+    throw new NotFoundError(`著者が見つかりません: ${authorId}`);
+  }
+
+  // Base64画像のデコードとバリデーション
+  const imageBuffer = decodeAndValidateBase64Image(imageBase64);
+
+  // S3にサイン画像をアップロード
+  const signId = uuidv4();
+  const imageKey = `signs/${signId}/sign.png`;
+
+  await storageService.upload({
+    key: imageKey,
+    body: imageBuffer,
+    contentType: 'image/png',
+    serverSideEncryption: 'AES256',
+  });
+
+  // サインデータをDBに保存
+  // canvas_dataは外部APIからの登録なのでnull（CanvasデータはGUI経由でのみ設定）
+  const signResult = await db.query<{
+    id: string;
+    author_id: string;
+    name: string;
+    type: string;
+    image_key: string;
+    is_default: boolean;
+    created_at: Date;
+  }>(
+    `INSERT INTO signs (id, author_id, name, type, image_key, canvas_data, is_default)
+     VALUES ($1, $2, $3, $4, $5, $6, false)
+     RETURNING id, author_id, name, type, image_key, is_default, created_at`,
+    [signId, authorId, name, type, imageKey, JSON.stringify({})]
+  );
+
+  const row = signResult.rows[0];
+
+  logger.info('External sign created', {
+    signId: row.id,
+    authorId: row.author_id,
+    name: row.name,
+  });
+
+  return {
+    id: row.id,
+    authorId: row.author_id,
+    name: row.name,
+    type: row.type,
+    imageUrl: null, // 署名付きURLはsignedUrlで取得するため、ここではnull
+    isDefault: row.is_default,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * 指定IDのサインデータを取得する
+ *
+ * @param signId - サインID（UUID）
+ * @returns サインレコード（署名付き画像URLを含む）
+ * @throws {NotFoundError} サインが見つからない場合
+ */
+export async function getExternalSign(signId: string): Promise<ExternalSignRecord> {
+  const result = await db.query<{
+    id: string;
+    author_id: string;
+    name: string;
+    type: string;
+    image_key: string | null;
+    is_default: boolean;
+    created_at: Date;
+  }>(
+    `SELECT id, author_id, name, type, image_key, is_default, created_at
+     FROM signs
+     WHERE id = $1`,
+    [signId]
+  );
+
+  if (result.rows.length === 0) {
+    throw new NotFoundError(`サインが見つかりません: ${signId}`);
+  }
+
+  const row = result.rows[0];
+
+  // 画像URLを生成（署名付きURL、有効期限: 1時間）
+  let imageUrl: string | null = null;
+  if (row.image_key) {
+    try {
+      imageUrl = await storageService.getSignedUrl(row.image_key, 3600);
+    } catch (error) {
+      // 署名付きURLの生成失敗はログのみ（レスポンス自体は返す）
+      logger.warn('Failed to generate signed URL for sign image', {
+        signId: row.id,
+        imageKey: row.image_key,
+        error: (error as Error).message,
+      });
+    }
+  }
+
+  return {
+    id: row.id,
+    authorId: row.author_id,
+    name: row.name,
+    type: row.type,
+    imageUrl,
+    isDefault: row.is_default,
+    createdAt: row.created_at,
+  };
+}
+
+/** externalサービスをオブジェクト形式でもエクスポート */
+export const externalService = {
+  grantBookAccess,
+  deleteBookAccess,
+  listBookAccess,
+  createExternalSign,
+  getExternalSign,
+};

--- a/output_system/backend/test/controllers/api-key.controller.test.ts
+++ b/output_system/backend/test/controllers/api-key.controller.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @file api-key.controller.test.ts
+ * @description API Key管理コントローラーのユニットテスト
+ *
+ * テスト対象:
+ * - listApiKeys: APIキー一覧取得
+ * - createApiKey: APIキー発行
+ * - getApiKey: APIキー詳細取得
+ * - deactivateApiKey: APIキー無効化
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import {
+  listApiKeys,
+  createApiKey,
+  getApiKey,
+  deactivateApiKey,
+} from '../../src/controllers/api-key.controller';
+import { apiKeyService } from '../../src/services/api-key.service';
+import { NotFoundError } from '../../src/utils/errors';
+
+// api-key.serviceをモック
+jest.mock('../../src/services/api-key.service', () => ({
+  apiKeyService: {
+    listApiKeys: jest.fn(),
+    createApiKey: jest.fn(),
+    getApiKey: jest.fn(),
+    deactivateApiKey: jest.fn(),
+  },
+}));
+
+// express-validatorのresult関数をモック
+jest.mock('express-validator', () => ({
+  validationResult: jest.fn().mockReturnValue({
+    isEmpty: () => true,
+    array: () => [],
+  }),
+}));
+
+import { validationResult } from 'express-validator';
+const mockValidationResult = validationResult as jest.MockedFunction<typeof validationResult>;
+
+/** テスト用のAPIキーレコード */
+const mockApiKeyRecord = {
+  id: 'api-key-uuid-1234',
+  name: 'Test API Key',
+  description: 'Integration test key',
+  permissions: ['book_access', 'sign_create'],
+  isActive: true,
+  lastUsedAt: null,
+  expiresAt: null,
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+};
+
+/** Expressのモックリクエストを作成するヘルパー */
+function createMockRequest(options?: {
+  body?: Record<string, unknown>;
+  params?: Record<string, string>;
+  user?: { userId: string; email: string; role: 'admin' | 'author' | 'fan' };
+}): Partial<Request> {
+  return {
+    body: options?.body || {},
+    params: options?.params || {},
+    user: options?.user || { userId: 'admin-uuid', email: 'admin@example.com', role: 'admin' },
+  } as Partial<Request>;
+}
+
+/** Expressのモックレスポンスを作成するヘルパー */
+function createMockResponse(): { status: jest.Mock; json: jest.Mock } {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res;
+}
+
+/** nextのモック */
+function createMockNext(): jest.Mock {
+  return jest.fn();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // デフォルトでバリデーション成功を返す
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockValidationResult.mockReturnValue({
+    isEmpty: () => true,
+    array: () => [],
+  } as any);
+});
+
+// ===== listApiKeys テスト =====
+
+describe('listApiKeys', () => {
+  /**
+   * 【テスト対象】listApiKeys関数
+   * 【テスト内容】APIキーが存在する場合の一覧取得
+   * 【期待結果】200ステータスとAPIキー配列が返ること
+   */
+  it('should return 200 with list of API keys', async () => {
+    const mockKeys = [mockApiKeyRecord];
+    (apiKeyService.listApiKeys as jest.Mock).mockResolvedValue(mockKeys);
+
+    const req = createMockRequest() as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await listApiKeys(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      apiKeys: mockKeys,
+      count: 1,
+    });
+  });
+
+  /**
+   * 【テスト対象】listApiKeys関数
+   * 【テスト内容】APIキーが存在しない場合の一覧取得
+   * 【期待結果】200ステータスと空配列が返ること
+   */
+  it('should return 200 with empty list when no API keys exist', async () => {
+    (apiKeyService.listApiKeys as jest.Mock).mockResolvedValue([]);
+
+    const req = createMockRequest() as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await listApiKeys(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ apiKeys: [], count: 0 });
+  });
+
+  /**
+   * 【テスト対象】listApiKeys関数
+   * 【テスト内容】サービスがエラーをスローした場合
+   * 【期待結果】next()にエラーが渡されること
+   */
+  it('should call next with error when service throws', async () => {
+    (apiKeyService.listApiKeys as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const req = createMockRequest() as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await listApiKeys(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+// ===== createApiKey テスト =====
+
+describe('createApiKey', () => {
+  /**
+   * 【テスト対象】createApiKey関数
+   * 【テスト内容】有効なリクエストでAPIキーを発行する場合
+   * 【期待結果】201ステータスとAPIキー情報（plainKey含む）が返ること
+   */
+  it('should return 201 with new API key including plainKey', async () => {
+    const createResult = {
+      apiKey: mockApiKeyRecord,
+      plainKey: 'plain-text-api-key-64-chars-long-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    };
+    (apiKeyService.createApiKey as jest.Mock).mockResolvedValue(createResult);
+
+    const req = createMockRequest({
+      body: {
+        name: 'Test API Key',
+        description: 'Integration test key',
+        permissions: ['book_access'],
+      },
+    }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await createApiKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: mockApiKeyRecord,
+        plainKey: createResult.plainKey,
+        message: expect.stringContaining('APIキーが発行されました'),
+      })
+    );
+  });
+
+  /**
+   * 【テスト対象】createApiKey関数
+   * 【テスト内容】バリデーションエラーが発生した場合
+   * 【期待結果】ValidationError が next() に渡されること
+   */
+  it('should call next with ValidationError when validation fails', async () => {
+    // バリデーション失敗をシミュレート
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockValidationResult.mockReturnValue({
+      isEmpty: () => false,
+      array: () => [{ msg: 'キー名は必須です', type: 'field' }],
+    } as any);
+
+    const req = createMockRequest({ body: {} }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await createApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error.statusCode).toBe(400);
+  });
+});
+
+// ===== getApiKey テスト =====
+
+describe('getApiKey', () => {
+  /**
+   * 【テスト対象】getApiKey関数
+   * 【テスト内容】存在するAPIキーIDを指定した場合
+   * 【期待結果】200ステータスとAPIキー情報が返ること
+   */
+  it('should return 200 with API key details', async () => {
+    (apiKeyService.getApiKey as jest.Mock).mockResolvedValue(mockApiKeyRecord);
+
+    const req = createMockRequest({ params: { id: 'api-key-uuid-1234' } }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await getApiKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ apiKey: mockApiKeyRecord });
+  });
+
+  /**
+   * 【テスト対象】getApiKey関数
+   * 【テスト内容】存在しないAPIキーIDを指定した場合
+   * 【期待結果】NotFoundError が next() に渡されること
+   */
+  it('should call next with NotFoundError when API key does not exist', async () => {
+    (apiKeyService.getApiKey as jest.Mock).mockRejectedValue(
+      new NotFoundError('APIキーが見つかりません')
+    );
+
+    const req = createMockRequest({ params: { id: 'non-existent-uuid' } }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await getApiKey(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(404);
+  });
+});
+
+// ===== deactivateApiKey テスト =====
+
+describe('deactivateApiKey', () => {
+  /**
+   * 【テスト対象】deactivateApiKey関数
+   * 【テスト内容】存在するAPIキーを無効化する場合
+   * 【期待結果】200ステータスと無効化後のAPIキー情報が返ること
+   */
+  it('should return 200 with deactivated API key', async () => {
+    const deactivatedKey = { ...mockApiKeyRecord, isActive: false };
+    (apiKeyService.deactivateApiKey as jest.Mock).mockResolvedValue(deactivatedKey);
+
+    const req = createMockRequest({ params: { id: 'api-key-uuid-1234' } }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await deactivateApiKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: deactivatedKey,
+        message: 'APIキーを無効化しました',
+      })
+    );
+  });
+
+  /**
+   * 【テスト対象】deactivateApiKey関数
+   * 【テスト内容】存在しないAPIキーIDを指定した場合
+   * 【期待結果】NotFoundError が next() に渡されること
+   */
+  it('should call next with NotFoundError when API key does not exist', async () => {
+    (apiKeyService.deactivateApiKey as jest.Mock).mockRejectedValue(
+      new NotFoundError('APIキーが見つかりません')
+    );
+
+    const req = createMockRequest({ params: { id: 'non-existent-uuid' } }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await deactivateApiKey(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(404);
+  });
+});

--- a/output_system/backend/test/controllers/external.controller.test.ts
+++ b/output_system/backend/test/controllers/external.controller.test.ts
@@ -1,0 +1,394 @@
+/**
+ * @file external.controller.test.ts
+ * @description 外部連携APIコントローラーのユニットテスト
+ *
+ * テスト対象:
+ * - grantBookAccess: 書籍アクセス権付与
+ * - deleteBookAccess: アクセス権削除
+ * - listBookAccess: アクセス権一覧取得
+ * - createExternalSign: サインデータ登録
+ * - getExternalSign: サインデータ取得
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import {
+  grantBookAccess,
+  deleteBookAccess,
+  listBookAccess,
+  createExternalSign,
+  getExternalSign,
+} from '../../src/controllers/external.controller';
+import { externalService } from '../../src/services/external.service';
+import { NotFoundError } from '../../src/utils/errors';
+
+// external.serviceをモック
+jest.mock('../../src/services/external.service', () => ({
+  externalService: {
+    grantBookAccess: jest.fn(),
+    deleteBookAccess: jest.fn(),
+    listBookAccess: jest.fn(),
+    createExternalSign: jest.fn(),
+    getExternalSign: jest.fn(),
+  },
+}));
+
+// audit.middlewareをモック（DB接続不要）
+jest.mock('../../src/middleware/audit.middleware', () => ({
+  recordAuditLog: jest.fn().mockResolvedValue(undefined),
+  getClientIpAddress: jest.fn().mockReturnValue('127.0.0.1'),
+}));
+
+// express-validatorのresult関数をモック
+jest.mock('express-validator', () => ({
+  validationResult: jest.fn().mockReturnValue({
+    isEmpty: () => true,
+    array: () => [],
+  }),
+}));
+
+import { validationResult } from 'express-validator';
+const mockValidationResult = validationResult as jest.MockedFunction<typeof validationResult>;
+
+/** テスト用APIキー情報 */
+const mockApiKey = {
+  id: 'api-key-uuid-1234',
+  name: 'Test API Key',
+  permissions: ['book_access', 'sign_create'],
+  isActive: true,
+  expiresAt: null,
+};
+
+/** テスト用書籍アクセス権レコード */
+const mockBookAccessRecord = {
+  id: 'access-uuid-1234',
+  bookId: 'book-uuid-1234',
+  fanId: 'fan-uuid-5678',
+  signedBookId: null,
+  grantedBy: 'api',
+  externalReference: 'ORDER-001',
+  grantedAt: new Date('2024-01-01T00:00:00Z'),
+  expiresAt: null,
+};
+
+/** テスト用サインレコード */
+const mockSignRecord = {
+  id: 'sign-uuid-1234',
+  authorId: 'author-uuid-5678',
+  name: 'Test Sign',
+  type: 'common',
+  imageUrl: 'https://example.com/signs/sign.png',
+  isDefault: false,
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+};
+
+/** Expressのモックリクエストを作成するヘルパー */
+function createMockRequest(options?: {
+  body?: Record<string, unknown>;
+  params?: Record<string, string>;
+  query?: Record<string, string>;
+  apiKey?: typeof mockApiKey;
+}): Partial<Request> {
+  return {
+    body: options?.body || {},
+    params: options?.params || {},
+    query: options?.query || {},
+    apiKey: options?.apiKey ?? mockApiKey,
+    headers: { 'user-agent': 'test-agent' },
+    socket: { remoteAddress: '127.0.0.1' } as Request['socket'],
+  } as Partial<Request>;
+}
+
+/** Expressのモックレスポンスを作成するヘルパー */
+function createMockResponse(): { status: jest.Mock; json: jest.Mock } {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res;
+}
+
+/** nextのモック */
+function createMockNext(): jest.Mock {
+  return jest.fn();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // デフォルトでバリデーション成功を返す
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockValidationResult.mockReturnValue({
+    isEmpty: () => true,
+    array: () => [],
+  } as any);
+});
+
+// ===== grantBookAccess テスト =====
+
+describe('grantBookAccess', () => {
+  /**
+   * 【テスト対象】grantBookAccess関数
+   * 【テスト内容】有効なリクエストで書籍アクセス権を付与する場合
+   * 【期待結果】201ステータスとアクセス権レコードが返ること
+   */
+  it('should return 201 with book access record', async () => {
+    (externalService.grantBookAccess as jest.Mock).mockResolvedValue(mockBookAccessRecord);
+
+    const req = createMockRequest({
+      body: {
+        bookId: 'book-uuid-1234',
+        fanEmail: 'fan@example.com',
+        externalReference: 'ORDER-001',
+      },
+    }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await grantBookAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(mockBookAccessRecord);
+    expect(externalService.grantBookAccess).toHaveBeenCalledWith({
+      bookId: 'book-uuid-1234',
+      fanEmail: 'fan@example.com',
+      externalReference: 'ORDER-001',
+    });
+  });
+
+  /**
+   * 【テスト対象】grantBookAccess関数
+   * 【テスト内容】書籍が存在しない場合
+   * 【期待結果】NotFoundError が next() に渡されること
+   */
+  it('should call next with error when book is not found', async () => {
+    (externalService.grantBookAccess as jest.Mock).mockRejectedValue(
+      new NotFoundError('書籍が見つかりません')
+    );
+
+    const req = createMockRequest({
+      body: { bookId: 'non-existent-uuid', fanEmail: 'fan@example.com' },
+    }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await grantBookAccess(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(404);
+  });
+
+  /**
+   * 【テスト対象】grantBookAccess関数
+   * 【テスト内容】バリデーションエラーが発生した場合
+   * 【期待結果】ValidationError が next() に渡されること
+   */
+  it('should call next with ValidationError when validation fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockValidationResult.mockReturnValue({
+      isEmpty: () => false,
+      array: () => [{ msg: 'bookId は必須です', type: 'field' }],
+    } as any);
+
+    const req = createMockRequest({ body: {} }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await grantBookAccess(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(400);
+  });
+});
+
+// ===== deleteBookAccess テスト =====
+
+describe('deleteBookAccess', () => {
+  /**
+   * 【テスト対象】deleteBookAccess関数
+   * 【テスト内容】存在するアクセス権IDを指定した場合
+   * 【期待結果】200ステータスと完了メッセージが返ること
+   */
+  it('should return 200 with success message', async () => {
+    (externalService.deleteBookAccess as jest.Mock).mockResolvedValue(undefined);
+
+    const req = createMockRequest({ params: { id: 'access-uuid-1234' } }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await deleteBookAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ message: '書籍アクセス権を削除しました' });
+  });
+
+  /**
+   * 【テスト対象】deleteBookAccess関数
+   * 【テスト内容】存在しないアクセス権IDを指定した場合
+   * 【期待結果】404エラーが next() に渡されること
+   */
+  it('should call next with 404 error when access is not found', async () => {
+    (externalService.deleteBookAccess as jest.Mock).mockRejectedValue(
+      new NotFoundError('アクセス権が見つかりません')
+    );
+
+    const req = createMockRequest({ params: { id: 'non-existent-uuid' } }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await deleteBookAccess(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(404);
+  });
+});
+
+// ===== listBookAccess テスト =====
+
+describe('listBookAccess', () => {
+  /**
+   * 【テスト対象】listBookAccess関数
+   * 【テスト内容】フィルタなしでアクセス権一覧を取得する場合
+   * 【期待結果】200ステータスとアクセス権配列が返ること
+   */
+  it('should return 200 with list of book access records', async () => {
+    const mockList = [mockBookAccessRecord];
+    (externalService.listBookAccess as jest.Mock).mockResolvedValue(mockList);
+
+    const req = createMockRequest() as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await listBookAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      bookAccess: mockList,
+      count: 1,
+    });
+  });
+
+  /**
+   * 【テスト対象】listBookAccess関数
+   * 【テスト内容】bookIdでフィルタした場合
+   * 【期待結果】サービスに正しいフィルタが渡されること
+   */
+  it('should pass filters to service when query params are provided', async () => {
+    (externalService.listBookAccess as jest.Mock).mockResolvedValue([]);
+
+    const req = createMockRequest({
+      query: { bookId: 'book-uuid-1234', externalReference: 'ORDER-001' },
+    }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await listBookAccess(req, res, next);
+
+    expect(externalService.listBookAccess).toHaveBeenCalledWith({
+      bookId: 'book-uuid-1234',
+      fanId: undefined,
+      externalReference: 'ORDER-001',
+    });
+  });
+});
+
+// ===== createExternalSign テスト =====
+
+describe('createExternalSign', () => {
+  /**
+   * 【テスト対象】createExternalSign関数
+   * 【テスト内容】有効なBase64PNG画像でサインを登録する場合
+   * 【期待結果】201ステータスとサインレコードが返ること
+   */
+  it('should return 201 with sign record', async () => {
+    (externalService.createExternalSign as jest.Mock).mockResolvedValue(mockSignRecord);
+
+    const req = createMockRequest({
+      body: {
+        authorId: 'author-uuid-5678',
+        name: 'Test Sign',
+        type: 'common',
+        imageBase64: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      },
+    }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await createExternalSign(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(mockSignRecord);
+  });
+
+  /**
+   * 【テスト対象】createExternalSign関数
+   * 【テスト内容】著者が存在しない場合
+   * 【期待結果】404エラーが next() に渡されること
+   */
+  it('should call next with 404 error when author is not found', async () => {
+    (externalService.createExternalSign as jest.Mock).mockRejectedValue(
+      new NotFoundError('著者が見つかりません')
+    );
+
+    const req = createMockRequest({
+      body: {
+        authorId: 'non-existent-uuid',
+        name: 'Test Sign',
+        type: 'common',
+        imageBase64: 'dGVzdA==',
+      },
+    }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await createExternalSign(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(404);
+  });
+});
+
+// ===== getExternalSign テスト =====
+
+describe('getExternalSign', () => {
+  /**
+   * 【テスト対象】getExternalSign関数
+   * 【テスト内容】存在するサインIDを指定した場合
+   * 【期待結果】200ステータスとサインレコードが返ること
+   */
+  it('should return 200 with sign record', async () => {
+    (externalService.getExternalSign as jest.Mock).mockResolvedValue(mockSignRecord);
+
+    const req = createMockRequest({ params: { id: 'sign-uuid-1234' } }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await getExternalSign(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(mockSignRecord);
+  });
+
+  /**
+   * 【テスト対象】getExternalSign関数
+   * 【テスト内容】存在しないサインIDを指定した場合
+   * 【期待結果】404エラーが next() に渡されること
+   */
+  it('should call next with 404 error when sign is not found', async () => {
+    (externalService.getExternalSign as jest.Mock).mockRejectedValue(
+      new NotFoundError('サインが見つかりません')
+    );
+
+    const req = createMockRequest({ params: { id: 'non-existent-uuid' } }) as Request;
+    const res = createMockResponse() as unknown as Response;
+    const next = createMockNext() as NextFunction;
+
+    await getExternalSign(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(404);
+  });
+});

--- a/output_system/backend/test/middleware/api-key.middleware.test.ts
+++ b/output_system/backend/test/middleware/api-key.middleware.test.ts
@@ -1,0 +1,281 @@
+/**
+ * @file api-key.middleware.test.ts
+ * @description API Key認証ミドルウェアのユニットテスト
+ *
+ * テスト対象:
+ * - authenticateApiKey: API Key認証ミドルウェア
+ * - hashApiKey: API KeyのSHA-256ハッシュ化関数
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { authenticateApiKey, hashApiKey } from '../../src/middleware/api-key.middleware';
+import { UnauthorizedError } from '../../src/utils/errors';
+
+// データベースをモック
+jest.mock('../../src/config/database', () => ({
+  db: {
+    query: jest.fn(),
+  },
+}));
+
+import { db } from '../../src/config/database';
+const mockDb = db as jest.Mocked<typeof db>;
+
+/** Expressのモックリクエストを作成するヘルパー */
+function createMockRequest(apiKey?: string): Partial<Request> {
+  return {
+    headers: apiKey ? { 'x-api-key': apiKey } : {},
+    socket: { remoteAddress: '127.0.0.1' } as Request['socket'],
+  } as Partial<Request>;
+}
+
+/** Expressのモックレスポンスを作成するヘルパー */
+function createMockResponse(): Partial<Response> {
+  return {};
+}
+
+/** nextのモック */
+function createMockNext(): jest.Mock {
+  return jest.fn();
+}
+
+// テスト用APIキー
+const TEST_API_KEY = 'test-api-key-1234567890abcdef';
+const TEST_KEY_HASH = hashApiKey(TEST_API_KEY);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ===== hashApiKey 関数テスト =====
+
+describe('hashApiKey', () => {
+  /**
+   * 【テスト対象】hashApiKey関数
+   * 【テスト内容】同じAPIキーを入力した場合
+   * 【期待結果】常に同じハッシュ値を返すこと（決定性）
+   */
+  it('should return the same hash for the same input', () => {
+    const hash1 = hashApiKey('my-api-key');
+    const hash2 = hashApiKey('my-api-key');
+    expect(hash1).toBe(hash2);
+  });
+
+  /**
+   * 【テスト対象】hashApiKey関数
+   * 【テスト内容】異なるAPIキーを入力した場合
+   * 【期待結果】異なるハッシュ値を返すこと
+   */
+  it('should return different hashes for different inputs', () => {
+    const hash1 = hashApiKey('api-key-1');
+    const hash2 = hashApiKey('api-key-2');
+    expect(hash1).not.toBe(hash2);
+  });
+
+  /**
+   * 【テスト対象】hashApiKey関数
+   * 【テスト内容】SHA-256ハッシュの形式チェック
+   * 【期待結果】64文字の16進文字列を返すこと
+   */
+  it('should return a 64-character hex string (SHA-256)', () => {
+    const hash = hashApiKey('test-key');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ===== authenticateApiKey ミドルウェア テスト =====
+
+describe('authenticateApiKey middleware', () => {
+  /**
+   * 【テスト対象】authenticateApiKey関数
+   * 【テスト内容】有効なAPIキーをX-API-Keyヘッダーに含めた場合
+   * 【期待結果】req.apiKeyにキー情報がセットされ、next()が呼ばれること
+   */
+  it('should authenticate with a valid API key and call next()', async () => {
+    // モックDBが有効なキーレコードを返す
+    (mockDb.query as jest.Mock).mockImplementation((sql: string) => {
+      if (sql.includes('SELECT') && sql.includes('api_keys')) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: 'key-uuid-1234',
+              name: 'Test Key',
+              permissions: ['book_access', 'sign_create'],
+              is_active: true,
+              expires_at: null,
+            },
+          ],
+        });
+      }
+      // last_used_at更新のクエリ
+      return Promise.resolve({ rows: [] });
+    });
+
+    const req = createMockRequest(TEST_API_KEY) as Request;
+    const res = createMockResponse() as Response;
+    const next = createMockNext() as NextFunction;
+
+    await authenticateApiKey(req, res, next);
+
+    // next()が引数なしで呼ばれること（エラーなし）
+    expect(next).toHaveBeenCalledWith();
+    expect(next).toHaveBeenCalledTimes(1);
+
+    // req.apiKeyに正しい情報がセットされること
+    expect(req.apiKey).toBeDefined();
+    expect(req.apiKey?.id).toBe('key-uuid-1234');
+    expect(req.apiKey?.name).toBe('Test Key');
+    expect(req.apiKey?.permissions).toEqual(['book_access', 'sign_create']);
+    expect(req.apiKey?.isActive).toBe(true);
+  });
+
+  /**
+   * 【テスト対象】authenticateApiKey関数
+   * 【テスト内容】X-API-Keyヘッダーが含まれていない場合
+   * 【期待結果】UnauthorizedError が next() に渡されること
+   */
+  it('should call next with UnauthorizedError when X-API-Key header is missing', async () => {
+    const req = createMockRequest() as Request; // ヘッダーなし
+    const res = createMockResponse() as Response;
+    const next = createMockNext() as NextFunction;
+
+    await authenticateApiKey(req, res, next);
+
+    // next()が呼ばれ、渡されたエラーが401であることを確認
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(401);
+  });
+
+  /**
+   * 【テスト対象】authenticateApiKey関数
+   * 【テスト内容】存在しないAPIキーが提供された場合
+   * 【期待結果】401エラーが next() に渡されること（情報漏洩防止）
+   */
+  it('should call next with 401 error when API key is not found', async () => {
+    // DBがレコードを返さない
+    (mockDb.query as jest.Mock).mockResolvedValue({ rows: [] });
+
+    const req = createMockRequest('invalid-api-key') as Request;
+    const res = createMockResponse() as Response;
+    const next = createMockNext() as NextFunction;
+
+    await authenticateApiKey(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(401);
+  });
+
+  /**
+   * 【テスト対象】authenticateApiKey関数
+   * 【テスト内容】無効化された（is_active = false）APIキーが提供された場合
+   * 【期待結果】401エラーが next() に渡されること
+   */
+  it('should call next with 401 error when API key is inactive', async () => {
+    (mockDb.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          id: 'key-uuid-inactive',
+          name: 'Inactive Key',
+          permissions: [],
+          is_active: false, // 無効化済み
+          expires_at: null,
+        },
+      ],
+    });
+
+    const req = createMockRequest(TEST_API_KEY) as Request;
+    const res = createMockResponse() as Response;
+    const next = createMockNext() as NextFunction;
+
+    await authenticateApiKey(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(401);
+  });
+
+  /**
+   * 【テスト対象】authenticateApiKey関数
+   * 【テスト内容】有効期限が切れたAPIキーが提供された場合
+   * 【期待結果】401エラーが next() に渡されること
+   */
+  it('should call next with 401 error when API key is expired', async () => {
+    const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000); // 昨日
+
+    (mockDb.query as jest.Mock).mockResolvedValue({
+      rows: [
+        {
+          id: 'key-uuid-expired',
+          name: 'Expired Key',
+          permissions: [],
+          is_active: true,
+          expires_at: pastDate, // 期限切れ
+        },
+      ],
+    });
+
+    const req = createMockRequest(TEST_API_KEY) as Request;
+    const res = createMockResponse() as Response;
+    const next = createMockNext() as NextFunction;
+
+    await authenticateApiKey(req, res, next);
+
+    const error = (next as jest.Mock).mock.calls[0][0];
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(401);
+  });
+
+  /**
+   * 【テスト対象】authenticateApiKey関数
+   * 【テスト内容】有効期限が未来のAPIキーが提供された場合
+   * 【期待結果】認証が成功し、next()が引数なしで呼ばれること
+   */
+  it('should authenticate successfully when API key has a future expiry date', async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000); // 明日
+
+    (mockDb.query as jest.Mock).mockImplementation((sql: string) => {
+      if (sql.includes('SELECT')) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: 'key-uuid-future',
+              name: 'Future Key',
+              permissions: [],
+              is_active: true,
+              expires_at: futureDate,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const req = createMockRequest(TEST_API_KEY) as Request;
+    const res = createMockResponse() as Response;
+    const next = createMockNext() as NextFunction;
+
+    await authenticateApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(req.apiKey?.id).toBe('key-uuid-future');
+  });
+
+  /**
+   * 【テスト対象】authenticateApiKey関数
+   * 【テスト内容】DBクエリが失敗した場合
+   * 【期待結果】エラーが next() に渡されること
+   */
+  it('should call next with error when database query fails', async () => {
+    (mockDb.query as jest.Mock).mockRejectedValue(new Error('DB connection error'));
+
+    const req = createMockRequest(TEST_API_KEY) as Request;
+    const res = createMockResponse() as Response;
+    const next = createMockNext() as NextFunction;
+
+    await authenticateApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});


### PR DESCRIPTION
## Summary

外部購入システムがAPI Key認証を使って、書籍アクセス権の付与・削除・一覧取得、サインデータの登録・取得をAPI経由で操作できるようになります。レート制限（100 req/min/API Key）と監査ログが適用されます。

### 実装内容

**対象PBI**: #17 PBI 5.2: 外部システムがAPIで書籍アクセス権を付与・サインを登録できる
- #47 Task 5.2.1: API Key認証とレート制限を実装する ✅
- #48 Task 5.2.2: 外部連携APIエンドポイントを実装する ✅

### 変更ファイル

**新規ミドルウェア**:
- `output_system/backend/src/middleware/api-key.middleware.ts` - X-API-Key認証（SHA-256ハッシュ照合）
- `output_system/backend/src/middleware/rate-limit.middleware.ts` - express-rate-limit（外部API: 100req/min、認証: 10req/min）

**新規サービス**:
- `output_system/backend/src/services/api-key.service.ts` - APIキー発行・一覧取得・無効化
- `output_system/backend/src/services/external.service.ts` - 書籍アクセス権CRUD・サインデータ登録・取得

**新規コントローラー**:
- `output_system/backend/src/controllers/api-key.controller.ts` - APIキー管理（admin用）
- `output_system/backend/src/controllers/external.controller.ts` - 外部連携APIエンドポイント

**新規ルーター**:
- `output_system/backend/src/routes/external.routes.ts` - 外部連携APIルート定義

**更新ファイル**:
- `output_system/backend/src/routes/admin.routes.ts` - APIキー管理エンドポイント追加
- `output_system/backend/src/routes/index.ts` - externalルーター登録
- `output_system/backend/src/middleware/audit.middleware.ts` - 外部連携・APIキー操作のAuditAction追加

**テスト**:
- `output_system/backend/test/middleware/api-key.middleware.test.ts` (9テスト)
- `output_system/backend/test/controllers/api-key.controller.test.ts` (10テスト)
- `output_system/backend/test/controllers/external.controller.test.ts` (11テスト)

## Test Plan

- [x] API Key認証で外部APIにアクセスできる（X-API-Keyヘッダー）
- [x] ファンに書籍アクセス権を付与できる（POST /api/external/book-access）
- [x] アクセス権を削除できる（DELETE /api/external/book-access/:id）
- [x] アクセス権一覧を取得できる（GET /api/external/book-access）
- [x] サインデータを登録できる（POST /api/external/signs）
- [x] サインデータを取得できる（GET /api/external/signs/:id）
- [x] 不正なAPI Keyでは401が返る
- [x] レート制限が適用される（429 Too Many Requests）
- [x] 監査ログにAPI操作が記録される
- [x] ユニットテスト 186件 全pass（新規30件追加）
- [x] Admin API から APIキーの発行・一覧・無効化ができる

## Screenshots

| 画面名 | スクリーンショット |
|--------|-------------------|
| 不正API Keyで401レスポンス | APIバックエンドのみ実装（フロントエンドAPIキー管理ページは今後対応） |

## Related Issues

- Closes #17

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)